### PR TITLE
Added workaround for test problems caused by ZendSearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+0.3.1
+-----
+
+- [ZendSeach] Added workaround to avoid Fatal errors after a test suite run caused by
+  the Lucene\Index __destruct() method. You can now configure the adapter to hide Exceptions
+  from the Index class.
+
 0.3
 ---
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -38,6 +38,7 @@ class Configuration implements ConfigurationInterface
                     ->arrayNode('zend_lucene')
                         ->addDefaultsifNotSet()
                         ->children()
+                            ->booleanNode('hide_index_exception')->defaultValue(false)->end()
                             ->scalarNode('basepath')->defaultValue('%kernel.root_dir%/data')->end()
                         ->end()
                     ->end()

--- a/DependencyInjection/MassiveSearchExtension.php
+++ b/DependencyInjection/MassiveSearchExtension.php
@@ -42,6 +42,7 @@ class MassiveSearchExtension extends Extension
     {
         $container->setAlias('massive_search.adapter', $config['adapter_id']);
         $container->setParameter('massive_search.adapter.zend_lucene.basepath', $config['adapters']['zend_lucene']['basepath']);
+        $container->setParameter('massive_search.adapter.zend_lucene.hide_index_exception', $config['adapters']['zend_lucene']['hide_index_exception']);
 
         $loader->load('search.xml');
     }

--- a/Resources/config/search.xml
+++ b/Resources/config/search.xml
@@ -22,6 +22,7 @@
         <service id="massive_search.adapter.zend_lucene" class="%massive_search.search.adapter.zend_lucene.class%">
             <argument type="service" id="massive_search.factory" />
             <argument>%massive_search.adapter.zend_lucene.basepath%</argument>
+            <argument>%massive_search.adapter.zend_lucene.hide_index_exception%</argument>
         </service>
 
         <!-- Search manager -->

--- a/Search/Adapter/Zend/Index.php
+++ b/Search/Adapter/Zend/Index.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ * This file is part of the Sulu CMS.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Massive\Bundle\SearchBundle\Search\Adapter\Zend;
+
+use ZendSearch\Lucene\Index as BaseIndex;
+
+/**
+ * This class adds the possibility to hide destructor errors
+ * which generally occur when running consecutive tests.
+ */
+class Index extends BaseIndex
+{
+    /**
+     * @Var boolean
+     */
+    private $hideDestructException = false;
+
+    /**
+     * Workaround for problems encountered when functional testing ZendSearch.
+     * The __destruct is called at the end of the test suite, and throws an
+     * error causing exit-code to be non-zero  even if there were no failures.
+     *
+     * Set to true to catch exceptions in the __destruct method
+     *
+     * @param boolean $hideDestructException
+     */
+    public function setHideException($hideDestructException)
+    {
+        $this->hideDestructException = $hideDestructException;
+    }
+
+    public function __destruct()
+    {
+        try {
+            parent::__destruct();
+        } catch (\Exception $e) {
+            if (false === $this->hideDestructException) {
+                throw $e;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added workaround to avoid Fatal errors after a test suite run caused by
the Lucene\Index __destruct() method. You can now configure the adapter
to hide Exceptions from the Index class.
