### PR TITLE
Allow configuration of default zend lucene character encoidng

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -46,6 +46,7 @@ class Configuration implements ConfigurationInterface
                             ->children()
                                 ->booleanNode('hide_index_exception')->defaultValue(false)->end()
                                 ->scalarNode('basepath')->defaultValue('%kernel.root_dir%/data')->end()
+                                ->scalarNode('encoding')->defaultValue('ISO8859-1')->end()
                             ->end()
                         ->end()
                         ->arrayNode('elastic')

--- a/DependencyInjection/MassiveSearchExtension.php
+++ b/DependencyInjection/MassiveSearchExtension.php
@@ -87,6 +87,7 @@ class MassiveSearchExtension extends Extension
     {
         $container->setParameter('massive_search.adapter.zend_lucene.basepath', $config['basepath']);
         $container->setParameter('massive_search.adapter.zend_lucene.hide_index_exception', $config['hide_index_exception']);
+        $container->setParameter('massive_search.adapter.zend_lucene.encoding', $config['encoding']);
         $loader->load('adapter_zendlucene.xml');
     }
 

--- a/Resources/config/adapter_zendlucene.xml
+++ b/Resources/config/adapter_zendlucene.xml
@@ -13,6 +13,7 @@
             <argument type="service" id="massive_search.factory" />
             <argument>%massive_search.adapter.zend_lucene.basepath%</argument>
             <argument>%massive_search.adapter.zend_lucene.hide_index_exception%</argument>
+            <argument>%massive_search.adapter.zend_lucene.encoding%</argument>
         </service>
 
     </services>

--- a/Search/Adapter/ZendLuceneAdapter.php
+++ b/Search/Adapter/ZendLuceneAdapter.php
@@ -73,6 +73,8 @@ class ZendLuceneAdapter implements AdapterInterface
         $this->factory = $factory;
         $this->hideIndexException = $hideIndexException;
         $this->encoding = $encoding;
+
+        QueryParser::setDefaultEncoding($this->encoding);
     }
 
     /**
@@ -129,7 +131,6 @@ class ZendLuceneAdapter implements AdapterInterface
      */
     public function search(SearchQuery $searchQuery)
     {
-        QueryParser::setDefaultEncoding($this->encoding);
         $indexNames = $searchQuery->getIndexes();
         $queryString = $searchQuery->getQueryString();
 

--- a/Search/Adapter/ZendLuceneAdapter.php
+++ b/Search/Adapter/ZendLuceneAdapter.php
@@ -19,6 +19,7 @@ use Massive\Bundle\SearchBundle\Search\SearchQuery;
 use Massive\Bundle\SearchBundle\Search\Adapter\Zend\Index;
 use ZendSearch\Lucene;
 use Symfony\Component\Filesystem\Filesystem;
+use ZendSearch\Lucene\Search\QueryParser;
 
 /**
  * Adapter for the ZendSearch library
@@ -55,16 +56,23 @@ class ZendLuceneAdapter implements AdapterInterface
     private $hideIndexException;
 
     /**
+     * @var string
+     */
+    private $encoding;
+
+    /**
      * @param string $basePath Base filesystem path for the index
      */
     public function __construct(
         Factory $factory,
         $basePath,
-        $hideIndexException = false
+        $hideIndexException = false,
+        $encoding = null
     ) {
         $this->basePath = $basePath;
         $this->factory = $factory;
         $this->hideIndexException = $hideIndexException;
+        $this->encoding = $encoding;
     }
 
     /**
@@ -82,7 +90,7 @@ class ZendLuceneAdapter implements AdapterInterface
         foreach ($document->getFields() as $field) {
             switch ($field->getType()) {
                 case Field::TYPE_STRING:
-                    $luceneField = Lucene\Document\Field::Text($field->getName(), $field->getValue());
+                    $luceneField = Lucene\Document\Field::Text($field->getName(), $field->getValue(), $this->encoding);
                     break;
                 default:
                     throw new \InvalidArgumentException(sprintf(
@@ -121,6 +129,7 @@ class ZendLuceneAdapter implements AdapterInterface
      */
     public function search(SearchQuery $searchQuery)
     {
+        QueryParser::setDefaultEncoding($this->encoding);
         $indexNames = $searchQuery->getIndexes();
         $queryString = $searchQuery->getQueryString();
 

--- a/Tests/Resources/app/config/massivesearchbundle.yml
+++ b/Tests/Resources/app/config/massivesearchbundle.yml
@@ -12,3 +12,4 @@ massive_search:
 parameters:
     massive_search.adapter.zend_lucene.basepath: %kernel.root_dir%/cache/data
     massive_search.adapter.zend_lucene.hide_index_exception: true
+    massive_search.adapter.zend_lucene.encoding: ISO8859-1

--- a/Tests/Unit/DependencyInjection/MassiveSearchExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/MassiveSearchExtensionTest.php
@@ -79,6 +79,7 @@ class MassiveSearchExtensionTest extends AbstractExtensionTestCase
                 array(
                     'basepath' => 'foobar',
                     'hide_index_exception' => true,
+                    'encoding' => 'UTF-8',
                 ),
                 array(
                     'massive_search.adapter.zend_lucene.basepath' => 'foobar',

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "symfony-cmf/testing": "dev-master",
         "symfony/filesystem": "~2.4",
         "symfony/console": "~2.5",
+        "symfony/expression-language": "~2.4",
         "phpspec/prophecy-phpunit": "~1.0",
         "matthiasnoback/symfony-dependency-injection-test": "0.7.1",
         "doctrine/doctrine-bundle": "~1.3",


### PR DESCRIPTION
Allows proper indexing and searching of international characters with Zend Lucene.