### PR TITLE
Optimize zend index after indexing and aggregate fields

### DIFF
--- a/Resources/config/adapter_zendlucene.xml
+++ b/Resources/config/adapter_zendlucene.xml
@@ -14,6 +14,7 @@
             <argument>%massive_search.adapter.zend_lucene.basepath%</argument>
             <argument>%massive_search.adapter.zend_lucene.hide_index_exception%</argument>
             <argument>%massive_search.adapter.zend_lucene.encoding%</argument>
+            <tag name="kernel.event_listener" event="massive_search.index_rebuild" method="optizeIndexAfterRebuild" priority="-999" />
         </service>
 
     </services>

--- a/Search/Adapter/ZendLuceneAdapter.php
+++ b/Search/Adapter/ZendLuceneAdapter.php
@@ -20,6 +20,7 @@ use Massive\Bundle\SearchBundle\Search\Adapter\Zend\Index;
 use ZendSearch\Lucene;
 use Symfony\Component\Filesystem\Filesystem;
 use ZendSearch\Lucene\Search\QueryParser;
+use Massive\Bundle\SearchBundle\Search\Event\IndexRebuildEvent;
 
 /**
  * Adapter for the ZendSearch library
@@ -89,10 +90,16 @@ class ZendLuceneAdapter implements AdapterInterface
 
         $luceneDocument = new Lucene\Document();
 
+        $values = array();
         foreach ($document->getFields() as $field) {
             switch ($field->getType()) {
                 case Field::TYPE_STRING:
+<<<<<<< HEAD
                     $luceneField = Lucene\Document\Field::Text($field->getName(), $field->getValue(), $this->encoding);
+=======
+                    $luceneField = Lucene\Document\Field::unIndexed($field->getName(), $field->getValue());
+                    $values[] = $field->getValue();
+>>>>>>> Optimize zend index after indexing and aggregate fields
                     break;
                 default:
                     throw new \InvalidArgumentException(sprintf(
@@ -105,13 +112,14 @@ class ZendLuceneAdapter implements AdapterInterface
         }
 
         // add meta fields - used internally for showing the search results, etc.
-        $luceneDocument->addField(Lucene\Document\Field::Keyword(self::ID_FIELDNAME, $document->getId()));
-        $luceneDocument->addField(Lucene\Document\Field::Keyword(self::URL_FIELDNAME, $document->getUrl()));
-        $luceneDocument->addField(Lucene\Document\Field::Keyword(self::TITLE_FIELDNAME, $document->getTitle()));
-        $luceneDocument->addField(Lucene\Document\Field::Keyword(self::DESCRIPTION_FIELDNAME, $document->getDescription()));
-        $luceneDocument->addField(Lucene\Document\Field::Keyword(self::LOCALE_FIELDNAME, $document->getLocale()));
-        $luceneDocument->addField(Lucene\Document\Field::Keyword(self::CLASS_TAG, $document->getClass()));
-        $luceneDocument->addField(Lucene\Document\Field::Keyword(self::IMAGE_URL, $document->getImageUrl()));
+        $luceneDocument->addField(Lucene\Document\Field::keyword(self::ID_FIELDNAME, $document->getId()));
+        $luceneDocument->addField(Lucene\Document\Field::unStored('__content__', implode(' ', $values)));
+        $luceneDocument->addField(Lucene\Document\Field::unIndexed(self::URL_FIELDNAME, $document->getUrl()));
+        $luceneDocument->addField(Lucene\Document\Field::unIndexed(self::TITLE_FIELDNAME, $document->getTitle()));
+        $luceneDocument->addField(Lucene\Document\Field::unIndexed(self::DESCRIPTION_FIELDNAME, $document->getDescription()));
+        $luceneDocument->addField(Lucene\Document\Field::unIndexed(self::LOCALE_FIELDNAME, $document->getLocale()));
+        $luceneDocument->addField(Lucene\Document\Field::unIndexed(self::CLASS_TAG, $document->getClass()));
+        $luceneDocument->addField(Lucene\Document\Field::unIndexed(self::IMAGE_URL, $document->getImageUrl()));
 
         $index->addDocument($luceneDocument);
     }
@@ -315,5 +323,14 @@ class ZendLuceneAdapter implements AdapterInterface
         $index->setHideException($this->hideIndexException);
 
         return $index;
+    }
+
+    public function optizeIndexAfterRebuild(IndexRebuildEvent $event)
+    {
+        foreach ($this->listIndexes() as $indexName) {
+            $event->getOutput()->writeln(sprintf('<info>Optimizing zend lucene index:</info> %s', $indexName));
+            $index = $this->getLuceneIndex($indexName);
+            $index->optimize();
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "elasticsearch/elasticsearch": "~1.3",
         "symfony-cmf/testing": "dev-master",
         "symfony/filesystem": "~2.4",
+        "symfony/expression-language": "~2.4",
         "symfony/console": "~2.5",
         "symfony/expression-language": "~2.4",
         "phpspec/prophecy-phpunit": "~1.0",


### PR DESCRIPTION
This PR improves the speed of the zend lucene search:

- Optimizes the index after an index rebuild
- Aggregates the indexed field values into a single (unstored) field

With a test this reduces the query time from 1.1s to 0.2s
Optimizing the index saves ~300ms
Aggregating the fields saves ~600ms

Original search:

````
$ ./app/console massive:search:query "anton" 
168 result(s) in 3.827782
````

With optimization and aggregation:

````
$ ./app/console massive:search:query "anton" 
168 result(s) in 1.634348s
````