### PR TITLE
Order by score when searching with the Zend adapter

### DIFF
--- a/Search/Adapter/ZendLuceneAdapter.php
+++ b/Search/Adapter/ZendLuceneAdapter.php
@@ -190,6 +190,15 @@ class ZendLuceneAdapter implements AdapterInterface
             $hits[] = $hit;
         }
 
+        // The MultiSearcher does not support sorting, so we do it here.
+        usort($hits, function ($documentA, $documentB) {
+            if ($documentA->getScore() < $documentB->getScore()) {
+                return true;
+            }
+
+            return false;
+        });
+
         return $hits;
     }
 


### PR DESCRIPTION
The Zend Lucene `MultiSearcher` does not currently support ordering. This PR does a `usort` over the query hits to order them by score.
