### PR TITLE
Added index strategy

### DIFF
--- a/Search/Factory.php
+++ b/Search/Factory.php
@@ -47,9 +47,9 @@ class Factory
      *
      * @return Field
      */
-    public function createField($name, $value, $type = Field::TYPE_STRING)
+    public function createField($name, $value, $type = Field::TYPE_STRING, $indexStrategy = null)
     {
-        return new Field($name, $value, $type);
+        return new Field($name, $value, $type, $indexStrategy);
     }
 
     /**

--- a/Search/Field.php
+++ b/Search/Field.php
@@ -30,7 +30,26 @@ class Field
      */
     protected $value;
 
+    /**
+     * @var string
+     */
+    protected $indexStrategy;
+
+    /**
+     * Store the field as a string
+     */
     const TYPE_STRING = 'string';
+
+    /**
+     * Aggregate the fields in a single aggregate field for indexing and
+     * store the fields
+     */
+    const INDEX_AGGREGATE = 'aggregate';
+
+    /**
+     * Index, but do not sture the field
+     */
+    const INDEX_UNSTORED = 'unstored';
 
     public static function getValidTypes()
     {
@@ -39,11 +58,12 @@ class Field
         );
     }
 
-    public function __construct($name, $value, $type = self::TYPE_STRING)
+    public function __construct($name, $value, $type = self::TYPE_STRING, $indexStrategy = null)
     {
         $this->name = $name;
         $this->value = $value;
         $this->type = $type;
+        $this->indexStrategy = $indexStrategy;
     }
 
     /**
@@ -104,5 +124,25 @@ class Field
     public function setValue($value)
     {
         $this->value = $value;
+    }
+
+    /**
+     * Get the index strategy
+     *
+     * @return string One of Field::INDEX_*
+     */
+    public function getIndexStrategy() 
+    {
+        return $this->indexStrategy;
+    }
+
+    /**
+     * Set the index strategy
+     *
+     * @param string $indexStrategy One of Field::INDEX_*
+     */
+    public function setIndexStrategy($indexStrategy)
+    {
+        $this->indexStrategy = $indexStrategy;
     }
 }

--- a/Search/ObjectToDocumentConverter.php
+++ b/Search/ObjectToDocumentConverter.php
@@ -127,19 +127,20 @@ class ObjectToDocumentConverter
     private function populateDocument($document, $object, $fieldMapping, $prefix = '')
     {
         foreach ($fieldMapping as $fieldName => $mapping) {
-            if (!isset($mapping['field'])) {
-                throw new \RuntimeException(sprintf(
-                    'Mapping for "%s" does not have "field" key',
-                    $fieldName
-                ));
+            $requiredMappings = array('field', 'type');
+
+            foreach ($requiredMappings as $requiredMapping) {
+                if (!isset($mapping[$requiredMapping])) {
+                    throw new \RuntimeException(sprintf(
+                        'Mapping for "%s" does not have "%s" key',
+                        $requiredMapping
+                    ));
+                }
             }
 
-            if (!isset($mapping['type'])) {
-                throw new \RuntimeException(sprintf(
-                    'Mapping for "%s" does not have "type" key',
-                    $fieldName
-                ));
-            }
+            $mapping = array_merge(array(
+                'index_strategy' => null,
+            ), $mapping);
 
             if ($mapping['type'] == 'complex') {
                 if (!isset($mapping['mapping'])) {
@@ -159,7 +160,8 @@ class ObjectToDocumentConverter
                         $document,
                         $childObject,
                         $mapping['mapping']->getFieldMapping(),
-                        $prefix . $fieldName . $i
+                        $prefix . $fieldName . $i,
+                        $mapping['index_strategy']
                     );
                 }
 
@@ -173,7 +175,8 @@ class ObjectToDocumentConverter
                     $this->factory->createField(
                         $prefix . $fieldName,
                         $value,
-                        $mapping['type']
+                        $mapping['type'],
+                        $mapping['index_strategy']
                     )
                 );
 
@@ -185,7 +188,8 @@ class ObjectToDocumentConverter
                     $this->factory->createField(
                         $prefix . $fieldName . $key,
                         $itemValue,
-                        $mapping['type']
+                        $mapping['type'],
+                        $mapping['index_strategy']
                     )
                 );
             }

--- a/Search/SearchManager.php
+++ b/Search/SearchManager.php
@@ -239,7 +239,7 @@ class SearchManager implements SearchManagerInterface
      *
      * @return string[]
      */
-    private function getIndexNames($categories = null)
+    public function getIndexNames($categories = null)
     {
         $classNames = $this->metadataFactory->getAllClassNames();
         $indexNames = array();


### PR DESCRIPTION
This PR introduces the possilbity to define an INDEX_STRATEGY.

This determines how user fields are stored in the search implementation, currently:

- `INDEX_AGGREGATE`: Index the fields in a single aggregate field, but store them individually (for performance)
- `INDEX_UNSTORED`: Index the field but do not store it.

This is currently only applying to Zend Lucene. Elastic Search will index all fields separtely.

Note these things are currenlty only exposed to the Drivers. No support is avaiilable to map these fields.