### PR TITLE
Temporarily disabled global search feature of test adapter

### DIFF
--- a/Search/Adapter/TestAdapter.php
+++ b/Search/Adapter/TestAdapter.php
@@ -87,7 +87,7 @@ class TestAdapter implements AdapterInterface
     public function search(SearchQuery $searchQuery)
     {
         $hits = array();
-        $indexes = $searchQuery->getIndexes() ? : array_keys($this->documents);
+        $indexes = $searchQuery->getIndexes();
 
         foreach ($indexes as $index) {
             if (!isset($this->documents[$index])) {


### PR DESCRIPTION
Disabling this feature for now as it is not required by any tests and it causes a regression in the Sulu tests.

See https://github.com/massiveart/MassiveSearchBundle/issues/38