### PR TITLE
Allow indexed and stored field mapping for Zend Lucene

### DIFF
--- a/Search/Adapter/ZendLuceneAdapter.php
+++ b/Search/Adapter/ZendLuceneAdapter.php
@@ -139,6 +139,13 @@ class ZendLuceneAdapter implements AdapterInterface
                         $this->encoding
                     );
                     break;
+                case Field::INDEX_STORED_INDEXED:
+                    $luceneField = Lucene\Document\Field::text(
+                        $field->getName(),
+                        $field->getValue(),
+                        $this->encoding
+                    );
+                    break;
                 default:
                     throw new \InvalidArgumentException(
                         sprintf(

--- a/Search/Field.php
+++ b/Search/Field.php
@@ -51,6 +51,11 @@ class Field
      */
     const INDEX_UNSTORED = 'unstored';
 
+    /**
+     * Indexed and stored
+     */
+    const INDEX_STORED_INDEXED = 'stored_indexed';
+
     public static function getValidTypes()
     {
         return array(


### PR DESCRIPTION
Adds the posibility to explicitly map a field to be both indexed and stored.

Note this currently only applies to ZendLucene.