### PR TITLE
Use "store" and "index" fields to determine how fields are indexed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,15 @@ dev-develop
   configuration
 - [Search] If not localized managed indexes exist then a global search is
   performed: https://github.com/massiveart/MassiveSearchBundle/issues/38
+- [Metadata] **BC BREAK**: Removed index strategies, replaced with explicit `stored` and
+  `indexed` and `aggregate` flags.
 
 0.5.1
 -----
 
 ### Features
 
-- [ZendLucene] Add index type 'INDEX_STORED_INDEXED'
+- [ZendLucene] Add index strategy 'INDEX_STORED_INDEXED'
 
 0.5.0
 -----

--- a/Search/Field.php
+++ b/Search/Field.php
@@ -31,30 +31,36 @@ class Field
     protected $value;
 
     /**
-     * @var string
+     * The value should be stored (i.e. it should be retrievable).
+     *
+     * @var boolean
      */
-    protected $indexStrategy;
+    protected $stored = true;
+
+    /**
+     * The value should be indexed (i.e. it should be searchable).
+     *
+     * @var boolean
+     */
+    protected $indexed = true;
+
+    /**
+     * Aggregate the values with other aggregate values into an indexed
+     * aggregate field (this can have performance benefits on certain
+     * implementations, like Zend Lucene, as it reduces the number of indexed
+     * fields on the document).
+     *
+     * Note for this to be beneficial the field should NOT be indexed (as the
+     * field value will be tokenized and indexed in the aggregate field).
+     *
+     * @var boolean
+     */
+    protected $aggregate = false;
 
     /**
      * Store the field as a string
      */
     const TYPE_STRING = 'string';
-
-    /**
-     * Aggregate the fields in a single aggregate field for indexing and
-     * store the fields
-     */
-    const INDEX_AGGREGATE = 'aggregate';
-
-    /**
-     * Index, but do not sture the field
-     */
-    const INDEX_UNSTORED = 'unstored';
-
-    /**
-     * Indexed and stored
-     */
-    const INDEX_STORED_INDEXED = 'stored_indexed';
 
     public static function getValidTypes()
     {
@@ -132,22 +138,54 @@ class Field
     }
 
     /**
-     * Get the index strategy
+     * Set if the field should be stored or not
+     * Stored field values are retrievable but not necessarily
+     * indexed.
      *
-     * @return string One of Field::INDEX_*
+     * @param boolean $boolean
      */
-    public function getIndexStrategy() 
+    public function setStored(bool $stored)
     {
-        return $this->indexStrategy;
+        $this->stored = $stored;
     }
 
     /**
-     * Set the index strategy
+     * Return true if the field should be stored
      *
-     * @param string $indexStrategy One of Field::INDEX_*
+     * @return boolean
      */
-    public function setIndexStrategy($indexStrategy)
+    public function isStored() 
     {
-        $this->indexStrategy = $indexStrategy;
+        return $this->stored;
+    }
+
+    /**
+     * Set if the field should be indexed
+     *
+     * @return boolean
+     */
+    public function isIndexed() 
+    {
+        return $this->indexed;
+    }
+
+    /**
+     * Aggregate the values of this field into a single indexed field.
+     *
+     * @param boolean $aggregate
+     */
+    public function setAggregate(bool $aggregate) 
+    {
+        $this->aggregate = $aggregate;
+    }
+
+    /**
+     * Return true if the field values should be in an aggregate indexed field.
+     *
+     * @return boolean
+     */
+    public function isAggregate()
+    {
+        return $this->aggregate;
     }
 }

--- a/Tests/Unit/Search/Adapter/ZendLuceneAdapterTest.php
+++ b/Tests/Unit/Search/Adapter/ZendLuceneAdapterTest.php
@@ -4,14 +4,32 @@ namespace Unit\Search\Adapter;
 
 use Prophecy\PhpUnit\ProphecyTestCase;
 use Massive\Bundle\SearchBundle\Search\Adapter\ZendLuceneAdapter;
+use Massive\Bundle\SearchBundle\Search\Field;
+use Symfony\Component\Filesystem\Filesystem;
 
 class ZendLuceneAdapterTest extends ProphecyTestCase
 {
+    private $dataPath;
     private $factory;
 
     public function setUp()
     {
         $this->factory = $this->prophesize('Massive\Bundle\SearchBundle\Search\Factory');
+        $this->document = $this->prophesize('Massive\Bundle\SearchBundle\Search\Document');
+        $this->field1 = $this->prophesize('Massive\Bundle\SearchBundle\Search\Field');
+        $this->field2 = $this->prophesize('Massive\Bundle\SearchBundle\Search\Field');
+        $filesystem = new Filesystem();
+        $this->dataPath = __DIR__ . '/../../../Resources/app/data';
+        if (file_exists($this->dataPath)) {
+            $filesystem->remove($this->dataPath);
+        }
+
+        $this->document->getUrl()->willReturn('http://foobar.com');
+        $this->document->getTitle()->willReturn('hallo');
+        $this->document->getDescription()->willReturn('Hallo Goodbye');
+        $this->document->getLocale()->willReturn('de');
+        $this->document->getClass()->willReturn('Class');
+        $this->document->getImageUrl()->willReturn('hallo.png');
     }
 
     /**
@@ -22,6 +40,96 @@ class ZendLuceneAdapterTest extends ProphecyTestCase
         $adapter = $this->createAdapter('/path-not-exist');
         $result = $adapter->listIndexes();
         $this->assertEquals(array(), $result);
+    }
+
+    /**
+     * It should use the correct zend type based on the store and index attributes
+     * of the field.
+     *
+     * @dataProvider provideIndexWithFieldType
+     */
+    public function testIndexWithFieldType($store, $index, $exception)
+    {
+        if ($exception) {
+            list($exceptionType, $exceptionMessage) = $exception;
+            $this->setExpectedException($exceptionType, $exceptionMessage);
+        }
+
+        $adapter = $this->createAdapter($this->dataPath);
+        $this->document->getId()->willReturn(12);
+        $this->document->getFields()->willReturn(array(
+            $this->field1
+        ));
+
+        $this->field1->getName()->wilLReturn('hallo');
+        $this->field1->getValue()->willReturn('goodbye');
+        $this->field1->getType()->willReturn(Field::TYPE_STRING);
+        $this->field1->isStored()->willReturn($store);
+        $this->field1->isIndexed()->willReturn($index);
+        $this->field1->isAggregate()->willReturn(true);
+
+        $luceneDocument = $adapter->index($this->document->reveal(), 'foo');
+
+        $luceneField = $luceneDocument->getField('hallo');
+        $this->assertEquals($store, $luceneField->isStored);
+        $this->assertEquals($index, $luceneField->isIndexed);
+    }
+
+    public function provideIndexWithFieldType()
+    {
+        return array(
+            array(
+                true,
+                true,
+                null
+            ),
+            array(
+                false,
+                true,
+                null
+            ),
+            array(
+                true,
+                false,
+                null
+            ),
+            array(
+                false,
+                false,
+                array('\InvalidArgumentException', 'cannot be both not indexed and not stored'),
+            )
+        );
+    }
+
+    /**
+     * If the field is aggregate, its value should be aggregated into the aggregate field
+     */
+    public function testIndexWithAggregate()
+    {
+        $adapter = $this->createAdapter($this->dataPath);
+        $this->document->getId()->willReturn(12);
+        $this->document->getFields()->willReturn(array(
+            $this->field1,
+            $this->field2,
+        ));
+
+        foreach (array('field1', 'field2') as $fieldName) {
+            $this->$fieldName->getName()->wilLReturn('hallo');
+            $this->$fieldName->getValue()->willReturn('goodbye');
+            $this->$fieldName->getType()->willReturn(Field::TYPE_STRING);
+            $this->$fieldName->isStored()->willReturn(true);
+            $this->$fieldName->isIndexed()->willReturn(true);
+            $this->$fieldName->isAggregate()->willReturn(true);
+        }
+
+        $luceneDocument = $adapter->index($this->document->reveal(), 'foo');
+        $aggregateField = $luceneDocument->getField(ZendLuceneAdapter::AGGREGATED_INDEXED_CONTENT);
+
+        $this->assertEquals(
+            'goodbye goodbye',
+            $aggregateField->value,
+            'It should aggregate the two field values'
+        );
     }
 
     private function createAdapter($basePath)


### PR DESCRIPTION
Fixes: https://github.com/massiveart/MassiveSearchBundle/issues/41

Use boolean fields `store` and `indexed` and `aggregate` to replace the single, non-web-scale, `index strategy` field.