### PR TITLE
Metadata provider

### DIFF
--- a/Behat/SearchManagerContext.php
+++ b/Behat/SearchManagerContext.php
@@ -306,7 +306,7 @@ class SearchManagerContext implements SnippetAcceptingContext, KernelAwareContex
     {
         return new SearchManager(
             $this->kernel->getContainer()->get($this->adapterId),
-            $this->kernel->getContainer()->get('massive_search.metadata.factory'),
+            $this->kernel->getContainer()->get('massive_search.metadata.provider.chain'),
             $this->kernel->getContainer()->get('massive_search.object_to_document_converter'),
             $this->kernel->getContainer()->get('event_dispatcher'),
             $this->kernel->getContainer()->get('massive_search.localization_strategy')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ dev-develop
 - [Metadata] **BC BREAK**: Removed index strategies, replaced with explicit `stored` and
   `indexed` and `aggregate` flags.
 - [Metadata] Added metadata cache
+- [Metadata] Added metadata providers
 
 0.5.1
 -----

--- a/DependencyInjection/Compiler/MetadataDriverPass.php
+++ b/DependencyInjection/Compiler/MetadataDriverPass.php
@@ -22,16 +22,16 @@ class MetadataDriverPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         if (!$container->hasDefinition(
-            'massive_search.metadata.driver.chain'
+            'massive_search.metadata.provider.chain'
         )) {
             return;
         }
 
         $driverChainDef = $container->getDefinition(
-            'massive_search.metadata.driver.chain'
+            'massive_search.metadata.provider.chain'
         );
 
-        $ids = $container->findTaggedServiceIds('massive_search.metadata.driver');
+        $ids = $container->findTaggedServiceIds('massive_search.metadata.provider');
         $serviceRefs = array();
 
         foreach (array_keys($ids) as $id) {

--- a/DependencyInjection/Compiler/MetadataProviderPass.php
+++ b/DependencyInjection/Compiler/MetadataProviderPass.php
@@ -15,29 +15,29 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * Compiler pass to register metadata drivers
+ * Compiler pass to register metadata providers
  */
-class MetadataDriverPass implements CompilerPassInterface
+class MetadataProviderPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
         if (!$container->hasDefinition(
-            'massive_search.metadata.driver.chain'
+            'massive_search.metadata.provider.chain'
         )) {
             return;
         }
 
         $driverChainDef = $container->getDefinition(
-            'massive_search.metadata.driver.chain'
+            'massive_search.metadata.provider.chain'
         );
 
-        $ids = $container->findTaggedServiceIds('massive_search.metadata.driver');
+        $ids = $container->findTaggedServiceIds('massive_search.metadata.provider');
         $serviceRefs = array();
 
         foreach (array_keys($ids) as $id) {
             $serviceRefs[] = new Reference($id);
         }
 
-        $driverChainDef->addArgument($serviceRefs);
+        $driverChainDef->replaceArgument(0, $serviceRefs);
     }
 }

--- a/MassiveSearchBundle.php
+++ b/MassiveSearchBundle.php
@@ -13,6 +13,7 @@ namespace Massive\Bundle\SearchBundle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Massive\Bundle\SearchBundle\DependencyInjection\Compiler\MetadataDriverPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Massive\Bundle\SearchBundle\DependencyInjection\Compiler\MetadataProviderPass;
 
 class MassiveSearchBundle extends Bundle
 {
@@ -20,5 +21,6 @@ class MassiveSearchBundle extends Bundle
     {
         parent::build($container);
         $container->addCompilerPass(new MetadataDriverPass());
+        $container->addCompilerPass(new MetadataProviderPass());
     }
 }

--- a/Resources/config/metadata.xml
+++ b/Resources/config/metadata.xml
@@ -34,6 +34,7 @@
         <!-- Metadata Provider Default -->
         <service id="massive_search.metadata.provider.default" class="%massive_search.metadata.provider.default.class%">
             <argument type="service" id="massive_search.metadata.factory" />
+            <tag name="massive_search.metadata.provider" />
         </service>
 
         <!-- Metadata Provide Chain -->

--- a/Resources/config/metadata.xml
+++ b/Resources/config/metadata.xml
@@ -11,6 +11,8 @@
         <parameter key="massive_search.metadata.factory.class">Metadata\MetadataFactory</parameter>
         <parameter key="massive_search.metadata.field_evaluator.class">Massive\Bundle\SearchBundle\Search\Metadata\FieldEvaluator</parameter>
         <parameter key="massive_search.metadata.cache.file_cache.class">Metadata\Cache\FileCache</parameter>
+        <parameter key="massive_search.metadata.provider.default.class">Massive\Bundle\SearchBundle\Search\Metadata\Provider\DefaultProvider</parameter>
+        <parameter key="massive_search.metadata.provider.chain.class">Massive\Bundle\SearchBundle\Search\Metadata\Provider\ChainProvider</parameter>
     </parameters>
 
     <services>
@@ -27,6 +29,16 @@
         <!-- Metadata File Cache -->
         <service id="massive_search.metadata.cache.file_cache" class="%massive_search.metadata.cache.file_cache.class%">
             <argument>%massive_search.metadata.cache_dir%</argument>
+        </service>
+
+        <!-- Metadata Provider Default -->
+        <service id="massive_search.metadata.provider.default" class="%massive_search.metadata.provider.default.class%">
+            <argument type="service" id="massive_search.metadata.factory" />
+        </service>
+
+        <!-- Metadata Provide Chain -->
+        <service id="massive_search.metadata.provider.chain" class="%massive_search.metadata.provider.chain.class%">
+            <argument type="collection" />
         </service>
 
         <!-- File Locator !-->

--- a/Resources/config/search.xml
+++ b/Resources/config/search.xml
@@ -25,7 +25,7 @@
         <!-- Search manager -->
         <service id="massive_search.search_manager" class="%massive_search.search_manager.class%">
             <argument type="service" id="massive_search.adapter" />
-            <argument type="service" id="massive_search.metadata.factory" />
+            <argument type="service" id="massive_search.metadata.provider.chain" />
             <argument type="service" id="massive_search.object_to_document_converter" />
             <argument type="service" id="event_dispatcher" />
             <argument type="service" id="massive_search.localization_strategy" />

--- a/Resources/docs/extending.rst
+++ b/Resources/docs/extending.rst
@@ -36,10 +36,33 @@ service in your main application configuration:
         services:
             factory: my.factory.service
 
-Metadata Drivers
-----------------
+Metadata Providers
+------------------
 
-Extend the ``Metadata\Driver\DriverInterface`` and add the tag
+Massive Search allows you to implement the metadata `ProviderInterface`,
+instances of which can load metadata from both domain object and search
+document instances.
+
+.. note:: 
+
+    The metadata system is based upon the `JMS Metadata`_ library, although it
+    diverges in that we allow you to load metadata from object instances instead
+    of only the class name. It is still possible to implement standard JMS
+    Metadata drivers as detailed below.
+
+To implement a provider just implement the ``Metadata\\ProviderInterface`` and
+add your class to the dependency injection configuration with the
+``massive_search.metadata.provider`` tag:
+
+.. code-block:: xml
+
+    <service id="massive_search.metadata.provider.foo" class="Vendor\\Search\\Provider">
+        <tag type="massive_search.metadata.provider" />
+    </service>
+
+You can also implement standard JMS serializer drivers. This would be optimal
+if you only need the class name to determine the metadata. Extend the
+``Metadata\Driver\DriverInterface`` and add the tag
 ``massive_search.metadata.driver`` tag to your implementations service
 definition.
 
@@ -50,8 +73,10 @@ definition.
         <tag type="massive_search.metadata.driver" />
     </service>
 
-This is non-trivial and you should use the existing XML implementation as a
-guide.
+.. note::
+
+    Adding new metadata providers is non-trivial, you should check the
+    existing code for implementation details.
 
 Events
 ------
@@ -110,3 +135,5 @@ Fired before a document is indexed. See the code for more information.
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Fired when a search request is performed. See the code for more information.
+
+.. JMS Metadata_: https://github.com/schmittjoh/metadata

--- a/Search/Metadata/Provider/ChainProvider.php
+++ b/Search/Metadata/Provider/ChainProvider.php
@@ -1,0 +1,75 @@
+<?php
+/*
+ * This file is part of the Sulu CMS.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Massive\Bundle\SearchBundle\Search\Metadata\Provider;
+
+use Massive\Bundle\SearchBundle\Search\Document;
+use Metadata\MetadataFactory;
+use Massive\Bundle\SearchBundle\Search\Metadata\ProviderInterface;
+
+/**
+ * Chain provider
+ */
+class ChainProvider implements ProviderInterface
+{
+    private $providers;
+
+    public function __construct(array $providers)
+    {
+        $this->providers = $providers;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getMetadataForObject($object)
+    {
+        foreach ($this->providers as $provider) {
+            $metadata = $provider->getMetadataForObject($object);
+
+            if (null !== $metadata) {
+                return $metadata;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAllMetadata()
+    {
+        $metadatas = array();
+        foreach ($this->providers as $provider) {
+            foreach ($provider->getAllMetadata() as $metadata) {
+                $metadatas[] = $metadata;
+            }
+        }
+
+        return $metadatas;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getMetadataForDocument(Document $document)
+    {
+        foreach ($this->providers as $provider) {
+            $metadata = $provider->getMetadataForDocument($document);
+
+            if (null !== $metadata) {
+                return $metadata;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Search/Metadata/Provider/DefaultProvider.php
+++ b/Search/Metadata/Provider/DefaultProvider.php
@@ -37,7 +37,13 @@ class DefaultProvider implements ProviderInterface
      */
     public function getMetadataForObject($object)
     {
-        return $this->metadataFactory->getMetadataForClass(get_class($object))->getOutsideClassMetadata();
+        $metadata = $this->metadataFactory->getMetadataForClass(get_class($object));
+
+        if (null === $metadata) {
+            return null;
+        }
+        
+        return $metadata->getOutsideClassMetadata();
     }
 
     /**
@@ -61,6 +67,12 @@ class DefaultProvider implements ProviderInterface
     {
         $className = $document->getClass();
 
-        return $this->metadataFactory->getMetadataForClass($className)->getOutsideClassMetadata();
+        $metadata = $this->metadataFactory->getMetadataForClass($className);
+        
+        if (null === $metadata) {
+            return null;
+        }
+        
+        return $metadata->getOutsideClassMetadata();
     }
 }

--- a/Search/Metadata/Provider/DefaultProvider.php
+++ b/Search/Metadata/Provider/DefaultProvider.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * This file is part of the Sulu CMS.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Massive\Bundle\SearchBundle\Search\Metadata\Provider;
+
+use Massive\Bundle\SearchBundle\Search\Document;
+use Metadata\MetadataFactory;
+use Massive\Bundle\SearchBundle\Search\Metadata\ProviderInterface;
+
+/**
+ * Default metadata provider
+ */
+class DefaultProvider implements ProviderInterface
+{
+    private $metadataFactory;
+
+    public function __construct(MetadataFactory $metadataFactory)
+    {
+        $this->metadataFactory = $metadataFactory;
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public function getMetadataForObject($object)
+    {
+        return $this->metadataFactory->getMetadataForClass(get_class($object));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAllMetadata()
+    {
+        $classNames = $this->metadataFactory->getAllClassNames();
+        $metadatas = array();
+        foreach ($classNames as $className) {
+            $metadatas[] = $this->metadataFactory->getMetadataForClass($className);
+        }
+
+        return $metadatas;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getMetadataForDocument(Document $document)
+    {
+        $className = $document->getClass();
+        return $this->metadataFactory->getMetadataForClass($className);
+    }
+}

--- a/Search/Metadata/Provider/DefaultProvider.php
+++ b/Search/Metadata/Provider/DefaultProvider.php
@@ -30,7 +30,7 @@ class DefaultProvider implements ProviderInterface
      */
     public function getMetadataForObject($object)
     {
-        return $this->metadataFactory->getMetadataForClass(get_class($object));
+        return $this->metadataFactory->getMetadataForClass(get_class($object))->getOutsideClassMetadata();
     }
 
     /**
@@ -41,7 +41,7 @@ class DefaultProvider implements ProviderInterface
         $classNames = $this->metadataFactory->getAllClassNames();
         $metadatas = array();
         foreach ($classNames as $className) {
-            $metadatas[] = $this->metadataFactory->getMetadataForClass($className);
+            $metadatas[] = $this->metadataFactory->getMetadataForClass($className)->getOutsideClassMetadata();
         }
 
         return $metadatas;
@@ -53,6 +53,6 @@ class DefaultProvider implements ProviderInterface
     public function getMetadataForDocument(Document $document)
     {
         $className = $document->getClass();
-        return $this->metadataFactory->getMetadataForClass($className);
+        return $this->metadataFactory->getMetadataForClass($className)->getOutsideClassMetadata();
     }
 }

--- a/Search/Metadata/Provider/DefaultProvider.php
+++ b/Search/Metadata/Provider/DefaultProvider.php
@@ -13,15 +13,22 @@ namespace Massive\Bundle\SearchBundle\Search\Metadata\Provider;
 use Massive\Bundle\SearchBundle\Search\Document;
 use Metadata\MetadataFactory;
 use Massive\Bundle\SearchBundle\Search\Metadata\ProviderInterface;
+use Metadata\MetadataFactoryInterface;
 
 /**
  * Default metadata provider
  */
 class DefaultProvider implements ProviderInterface
 {
+    /**
+     * @var MetadataFactoryInterface
+     */
     private $metadataFactory;
 
-    public function __construct(MetadataFactory $metadataFactory)
+    /**
+     * @param MetadataFactoryInterface $metadataFactory
+     */
+    public function __construct(MetadataFactoryInterface $metadataFactory)
     {
         $this->metadataFactory = $metadataFactory;
     }
@@ -53,6 +60,7 @@ class DefaultProvider implements ProviderInterface
     public function getMetadataForDocument(Document $document)
     {
         $className = $document->getClass();
+
         return $this->metadataFactory->getMetadataForClass($className)->getOutsideClassMetadata();
     }
 }

--- a/Search/Metadata/ProviderInterface.php
+++ b/Search/Metadata/ProviderInterface.php
@@ -11,9 +11,14 @@
 namespace Massive\Bundle\SearchBundle\Search\Metadata;
 
 use Massive\Bundle\SearchBundle\Search\Document;
+use Massive\Bundle\SearchBundle\Search\Metadata\ClassMetadata;
 
 /**
- * Provide a more flexible extension point for loading metadata.
+ * ProviderInterface instances provide search metadata for object instances.
+ *
+ * Currently this metadata system is implemented side-by-side with the JMS metadata
+ * loader which only provides support for loading metadata by class name, but does provide
+ * extra features such as hierachrical class metadata resolution.
  */
 interface ProviderInterface
 {

--- a/Search/Metadata/ProviderInterface.php
+++ b/Search/Metadata/ProviderInterface.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ * This file is part of the Sulu CMS.
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Massive\Bundle\SearchBundle\Search\Metadata;
+
+use Massive\Bundle\SearchBundle\Search\Document;
+
+/**
+ * Provide a more flexible extension point for loading metadata.
+ */
+interface ProviderInterface
+{
+    /**
+     * Load metadata for the given object
+     *
+     * @param object $object
+     */
+    public function getMetadataForObject($object);
+
+    /**
+     * Return all metadata instances
+     *
+     * @return ClassMetadata[]
+     */
+    public function getAllMetadata();
+
+    /**
+     * Return metadata for the given document
+     *
+     * @return ClassMetadata
+     */
+    public function getMetadataForDocument(Document $document);
+}

--- a/Tests/Unit/Search/Metadata/Provider/ChainProviderTest.php
+++ b/Tests/Unit/Search/Metadata/Provider/ChainProviderTest.php
@@ -3,9 +3,37 @@
 namespace Massive\Bundle\SearchBundle\Tests\Unit\Search\Metadata\Provider;
 
 use Massive\Bundle\SearchBundle\Search\Metadata\Provider\ChainProvider;
+use Massive\Bundle\SearchBundle\Search\Metadata\ProviderInterface;
+use Massive\Bundle\SearchBundle\Search\Metadata\ClassMetadata;
+use Massive\Bundle\SearchBundle\Search\Document;
 
 class ChainProviderTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var ProviderInterface
+     */
+    private $provider1;
+
+    /**
+     * @var ProviderInterface
+     */
+    private $provider2;
+
+    /**
+     * @var ClassMetadata
+     */
+    private $metadata;
+
+    /**
+     * @var Document
+     */
+    private $document;
+
+    /**
+     * @var ChainProvider
+     */
+    private $chainProvider;
+
     public function setUp()
     {
         $this->provider1 = $this->prophesize('Massive\Bundle\SearchBundle\Search\Metadata\ProviderInterface');

--- a/Tests/Unit/Search/Metadata/Provider/ChainProviderTest.php
+++ b/Tests/Unit/Search/Metadata/Provider/ChainProviderTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Massive\Bundle\SearchBundle\Tests\Unit\Search\Metadata\Provider;
+
+use Massive\Bundle\SearchBundle\Search\Metadata\Provider\ChainProvider;
+
+class ChainProviderTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->provider1 = $this->prophesize('Massive\Bundle\SearchBundle\Search\Metadata\ProviderInterface');
+        $this->provider2 = $this->prophesize('Massive\Bundle\SearchBundle\Search\Metadata\ProviderInterface');
+        $this->metadata = $this->prophesize('Massive\Bundle\SearchBundle\Search\Metadata\ClassMetadata');
+        $this->document = $this->prophesize('Massive\Bundle\SearchBundle\Search\Document');
+
+        $this->chainProvider = new ChainProvider(array(
+            $this->provider1->reveal(),
+            $this->provider2->reveal()
+        ));
+    }
+
+    /**
+     * It should get all metadatas
+     */
+    public function testGetAllMetadatas()
+    {
+        $this->provider1->getAllMetadata()->willReturn(array($this->metadata->reveal()));
+        $this->provider2->getAllMetadata()->willReturn(array($this->metadata->reveal()));
+        $metadatas = $this->chainProvider->getAllMetadata();
+
+        $this->assertEquals(array(
+            $this->metadata->reveal(),
+            $this->metadata->reveal(),
+        ), $metadatas);
+    }
+
+    /**
+     * It should return metadata for the given object
+     */
+    public function testGetMetadataForObject()
+    {
+        $object = new \stdClass;
+        $this->provider1->getMetadataForObject($object)->willReturn($this->metadata->reveal());
+        $metadata = $this->chainProvider->getMetadataForObject($object);
+        $this->assertSame($this->metadata->reveal(), $metadata);
+    }
+
+    /**
+     * It should return the metadata for a search document
+     */
+    public function testGetMetadataForDocument()
+    {
+        $this->provider1->getMetadataForDocument($this->document->reveal())->willReturn(null);
+        $this->provider2->getMetadataForDocument($this->document->reveal())->willReturn($this->metadata->reveal());
+        $metadata = $this->chainProvider->getMetadataForDocument($this->document->reveal());
+        $this->assertSame($this->metadata->reveal(), $metadata);
+    }
+}

--- a/Tests/Unit/Search/Metadata/Provider/DefaultProviderTest.php
+++ b/Tests/Unit/Search/Metadata/Provider/DefaultProviderTest.php
@@ -7,13 +7,43 @@ use Massive\Bundle\SearchBundle\Search\Metadata\Provider\DefaultProvider;
 use Massive\Bundle\SearchBundle\Search\Metadata\ClassMetadata;
 use Massive\Bundle\SearchBundle\Search\Document;
 use Metadata\ClassHierarchyMetadata;
+use Massive\Bundle\SearchBundle\Search\Metadata\ProviderInterface;
 
 class DefaultProviderTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var ProviderInterface
+     */
     private $provider;
+
+    /**
+     * @var MetadataFactory
+     */
     private $metadataFactory;
+
+    /**
+     * @var ClassMetadata
+     */
     private $metadata1;
+
+    /**
+     * @var ClassMetadata
+     */
     private $metadata2;
+
+    /**
+     * @var ClassHierarchyMetadata
+     */
+    private $hierarchyMetadata1;
+
+    /**
+     * @var ClassHierarchyMetadata
+     */
+    private $hierarchyMetadata2;
+
+    /**
+     * @var Document
+     */
     private $document;
 
     public function setUp()

--- a/Tests/Unit/Search/Metadata/Provider/DefaultProviderTest.php
+++ b/Tests/Unit/Search/Metadata/Provider/DefaultProviderTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Massive\Bundle\SearchBundle\Tests\Unit\Search\Metadata\Provider;
+
+use Metadata\MetadataFactory;
+use Massive\Bundle\SearchBundle\Search\Metadata\Provider\DefaultProvider;
+use Massive\Bundle\SearchBundle\Search\Metadata\ClassMetadata;
+use Massive\Bundle\SearchBundle\Search\Document;
+
+class DefaultProviderTest extends \PHPUnit_Framework_TestCase
+{
+    private $provider;
+    private $metadataFactory;
+    private $metadata1;
+    private $metadata2;
+    private $document;
+
+    public function setUp()
+    {
+        $this->metadataFactory = $this->prophesize(MetadataFactory::class);
+        $this->metadata1 = $this->prophesize(ClassMetadata::class);
+        $this->metadata2 = $this->prophesize(ClassMetadata::class);
+        $this->document = $this->prophesize(Document::class);
+        $this->provider = new DefaultProvider(
+            $this->metadataFactory->reveal()
+        );
+    }
+
+    /**
+     * It should return metadata for the given object
+     */
+    public function testGetMetadataForObject()
+    {
+        $object = new \stdClass;
+        $this->metadataFactory->getMetadataForClass('stdClass')->willReturn($this->metadata1->reveal());
+        $metadata = $this->provider->getMetadataForObject($object);
+        $this->assertSame($this->metadata1->reveal(), $metadata);
+    }
+
+    /**
+     * It should return all metadatas
+     */
+    public function testGetAllMetadata()
+    {
+        $this->metadataFactory->getAllClassNames()->willReturn(array('one', 'two'));
+        $this->metadataFactory->getMetadataForClass('one')->willReturn($this->metadata1->reveal());
+        $this->metadataFactory->getMetadataForClass('two')->willReturn($this->metadata2->reveal());
+        $metadatas = $this->provider->getAllMetadata();
+
+        $this->assertSame(array(
+            $this->metadata1->reveal(),
+            $this->metadata2->reveal(),
+        ), $metadatas);
+    }
+
+    /**
+     * It should return the metadata for a search document
+     */
+    public function testGetMetadataForDocument()
+    {
+        $this->document->getClass()->willReturn('Class');
+        $this->metadataFactory->getMetadataForClass('Class')->willReturn($this->metadata1->reveal());
+        $metadata = $this->provider->getMetadataForDocument($this->document->reveal());
+        $this->assertSame($this->metadata1->reveal(), $metadata);
+    }
+}

--- a/Tests/Unit/Search/Metadata/Provider/DefaultProviderTest.php
+++ b/Tests/Unit/Search/Metadata/Provider/DefaultProviderTest.php
@@ -18,14 +18,14 @@ class DefaultProviderTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->metadataFactory = $this->prophesize(MetadataFactory::class);
-        $this->metadata1 = $this->prophesize(ClassMetadata::class);
-        $this->metadata2 = $this->prophesize(ClassMetadata::class);
-        $this->hierarchyMetadata1 = $this->prophesize(ClassHierarchyMetadata::class);
-        $this->hierarchyMetadata2 = $this->prophesize(ClassHierarchyMetadata::class);
+        $this->metadataFactory = $this->prophesize('Metadata\MetadataFactory');
+        $this->metadata1 = $this->prophesize('Massive\Bundle\SearchBundle\Search\Metadata\ClassMetadata');
+        $this->metadata2 = $this->prophesize('Massive\Bundle\SearchBundle\Search\Metadata\ClassMetadata');
+        $this->hierarchyMetadata1 = $this->prophesize('Metadata\ClassHierarchyMetadata');
+        $this->hierarchyMetadata2 = $this->prophesize('Metadata\ClassHierarchyMetadata');
         $this->hierarchyMetadata1->getOutsideClassMetadata()->willReturn($this->metadata1);
         $this->hierarchyMetadata2->getOutsideClassMetadata()->willReturn($this->metadata2);
-        $this->document = $this->prophesize(Document::class);
+        $this->document = $this->prophesize('Massive\Bundle\SearchBundle\Search\Document');
         $this->provider = new DefaultProvider(
             $this->metadataFactory->reveal()
         );

--- a/Tests/Unit/Search/Metadata/Provider/DefaultProviderTest.php
+++ b/Tests/Unit/Search/Metadata/Provider/DefaultProviderTest.php
@@ -73,6 +73,17 @@ class DefaultProviderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * It should return null if no metadata for an object was found
+     */
+    public function testReturnNullNoMetdataForObject()
+    {
+        $object = new \stdClass;
+        $this->metadataFactory->getMetadataForClass('stdClass')->willReturn(null);
+        $metadata = $this->provider->getMetadataForObject($object);
+        $this->assertNull($metadata);
+    }
+
+    /**
      * It should return all metadatas
      */
     public function testGetAllMetadata()
@@ -97,5 +108,16 @@ class DefaultProviderTest extends \PHPUnit_Framework_TestCase
         $this->metadataFactory->getMetadataForClass('Class')->willReturn($this->hierarchyMetadata1->reveal());
         $metadata = $this->provider->getMetadataForDocument($this->document->reveal());
         $this->assertSame($this->metadata1->reveal(), $metadata);
+    }
+
+    /**
+     * It should return null if no metadata for document was found
+     */
+    public function testReturnNullNoMetdataForDocumnet()
+    {
+        $this->document->getClass()->willReturn('Class');
+        $this->metadataFactory->getMetadataForClass('Class')->willReturn(null);
+        $metadata = $this->provider->getMetadataForDocument($this->document->reveal());
+        $this->assertNull($metadata);
     }
 }

--- a/Tests/Unit/Search/Metadata/Provider/DefaultProviderTest.php
+++ b/Tests/Unit/Search/Metadata/Provider/DefaultProviderTest.php
@@ -6,6 +6,7 @@ use Metadata\MetadataFactory;
 use Massive\Bundle\SearchBundle\Search\Metadata\Provider\DefaultProvider;
 use Massive\Bundle\SearchBundle\Search\Metadata\ClassMetadata;
 use Massive\Bundle\SearchBundle\Search\Document;
+use Metadata\ClassHierarchyMetadata;
 
 class DefaultProviderTest extends \PHPUnit_Framework_TestCase
 {
@@ -20,6 +21,10 @@ class DefaultProviderTest extends \PHPUnit_Framework_TestCase
         $this->metadataFactory = $this->prophesize(MetadataFactory::class);
         $this->metadata1 = $this->prophesize(ClassMetadata::class);
         $this->metadata2 = $this->prophesize(ClassMetadata::class);
+        $this->hierarchyMetadata1 = $this->prophesize(ClassHierarchyMetadata::class);
+        $this->hierarchyMetadata2 = $this->prophesize(ClassHierarchyMetadata::class);
+        $this->hierarchyMetadata1->getOutsideClassMetadata()->willReturn($this->metadata1);
+        $this->hierarchyMetadata2->getOutsideClassMetadata()->willReturn($this->metadata2);
         $this->document = $this->prophesize(Document::class);
         $this->provider = new DefaultProvider(
             $this->metadataFactory->reveal()
@@ -32,7 +37,7 @@ class DefaultProviderTest extends \PHPUnit_Framework_TestCase
     public function testGetMetadataForObject()
     {
         $object = new \stdClass;
-        $this->metadataFactory->getMetadataForClass('stdClass')->willReturn($this->metadata1->reveal());
+        $this->metadataFactory->getMetadataForClass('stdClass')->willReturn($this->hierarchyMetadata1->reveal());
         $metadata = $this->provider->getMetadataForObject($object);
         $this->assertSame($this->metadata1->reveal(), $metadata);
     }
@@ -43,8 +48,8 @@ class DefaultProviderTest extends \PHPUnit_Framework_TestCase
     public function testGetAllMetadata()
     {
         $this->metadataFactory->getAllClassNames()->willReturn(array('one', 'two'));
-        $this->metadataFactory->getMetadataForClass('one')->willReturn($this->metadata1->reveal());
-        $this->metadataFactory->getMetadataForClass('two')->willReturn($this->metadata2->reveal());
+        $this->metadataFactory->getMetadataForClass('one')->willReturn($this->hierarchyMetadata1->reveal());
+        $this->metadataFactory->getMetadataForClass('two')->willReturn($this->hierarchyMetadata2->reveal());
         $metadatas = $this->provider->getAllMetadata();
 
         $this->assertSame(array(
@@ -59,7 +64,7 @@ class DefaultProviderTest extends \PHPUnit_Framework_TestCase
     public function testGetMetadataForDocument()
     {
         $this->document->getClass()->willReturn('Class');
-        $this->metadataFactory->getMetadataForClass('Class')->willReturn($this->metadata1->reveal());
+        $this->metadataFactory->getMetadataForClass('Class')->willReturn($this->hierarchyMetadata1->reveal());
         $metadata = $this->provider->getMetadataForDocument($this->document->reveal());
         $this->assertSame($this->metadata1->reveal(), $metadata);
     }


### PR DESCRIPTION
Experimental metadata provider.

The metadata provider provides a way to retrieve metadata based on attributes other than the class FQN.

The original JMS Metadata system remains the same, but it is wrapped in a `DefaultProvider`.

New providers can be registered by using the `massive_search.metadata.provider` tag. 