### PR TITLE
Added reindex directive

### DIFF
--- a/Resources/docs/commands.rst
+++ b/Resources/docs/commands.rst
@@ -28,6 +28,8 @@ Display status information for the current search implementation::
     | idx:product | {"size":11825,"nb_files":36,"nb_documents":10}               |
     +-------------+--------------------------------------------------------------+
 
+.. _command_search_index_rebuild:
+
 ``massive:search:index:rebuild``
 --------------------------------
 

--- a/Resources/docs/mapping.rst
+++ b/Resources/docs/mapping.rst
@@ -135,6 +135,28 @@ then it will be assumed that the object is not localized.
 
     </massive-search-mapping>
 
+Reindexing
+----------
+
+When reindexing your data using the :ref:`command_search_index_rebuild`
+command, you may not want to always reindex *all* of the entities in the
+database, for example you may want to limit the search results only to
+entities updated within the last 30 days.
+
+You can specify a specific method to use on the repository as follows:
+
+.. code-block:: xml
+
+    <!-- /path/to/YourBundle/Resources/config/massive-search/Product.xml -->
+    <massive-search-mapping xmlns="http://massiveart.com/schema/dic/massive-search-mapping">
+
+        <mapping class="Massive\Bundle\SearchBundle\Tests\Resources\TestBundle\Entity\Product">
+            <!-- ... -->
+            <reindex repository-method="findForLast30Days" />
+        </mapping>
+
+    </massive-search-mapping>
+
 Full example
 ------------
 
@@ -146,6 +168,7 @@ The following example uses all the mapping options:
     <massive-search-mapping xmlns="http://massiveart.com/schema/dic/massive-search-mapping">
 
         <mapping class="Massive\Bundle\SearchBundle\Tests\Resources\TestBundle\Entity\Product">
+            <reindex repository-method="findOnlySomethings" />
             <index name="product" />
             <id property="id" />
             <locale property="locale" />

--- a/Search/EventSubscriber/DoctrineOrmIndexRebuildSubscriber.php
+++ b/Search/EventSubscriber/DoctrineOrmIndexRebuildSubscriber.php
@@ -100,10 +100,10 @@ class DoctrineOrmIndexRebuildSubscriber implements EventSubscriberInterface
             $classMetadata = $searchMeta->getOutsideClassMetadata();
 
             if ($purge) {
-                $this->doPurge($output, $classMetadata, $class);
+                $this->doPurge($output, $classMetadata);
             }
 
-            $this->rebuildClass($output, $class);
+            $this->rebuildClass($output, $classMetadata);
         }
     }
 
@@ -114,9 +114,8 @@ class DoctrineOrmIndexRebuildSubscriber implements EventSubscriberInterface
      *
      * @param OutputInterface $output
      * @param ClassMetadata $classMetadata
-     * @param OrmMetadata $ormMetadata
      */
-    private function doPurge(OutputInterface $output, ClassMetadata $classMetadata, OrmMetadata $ormMetadata)
+    private function doPurge(OutputInterface $output, ClassMetadata $classMetadata)
     {
         foreach ($classMetadata->getIndexMetadatas() as $indexMetadata) {
             $indexName = $indexMetadata->getIndexName();
@@ -138,11 +137,13 @@ class DoctrineOrmIndexRebuildSubscriber implements EventSubscriberInterface
      * @param OutputInterface $output
      * @param OrmMetadata $ormMetadata
      */
-    private function rebuildClass(OutputInterface $output, OrmMetadata $ormMetadata)
+    private function rebuildClass(OutputInterface $output, ClassMetadata $class)
     {
-        $output->write('<comment>Rebuilding</comment>: ' . $ormMetadata->getName());
+        $output->write('<comment>Rebuilding</comment>: ' . $class->getName());
 
-        $objects = $this->objectManager->getRepository($ormMetadata->name)->findAll();
+        $repositoryMethod = $class->getReindexRepositoryMethod();
+        $repositoryMethod = $repositoryMethod ?: 'findAll';
+        $objects = $this->objectManager->getRepository($class->name)->$repositoryMethod();
 
         $count = 0;
         foreach ($objects as $object) {

--- a/Search/EventSubscriber/DoctrineOrmSubscriber.php
+++ b/Search/EventSubscriber/DoctrineOrmSubscriber.php
@@ -23,12 +23,12 @@ use Massive\Bundle\SearchBundle\Search\SearchManagerInterface;
 class DoctrineOrmSubscriber implements EventSubscriber
 {
     /**
-     * @var SearchManager
+     * @var SearchManagerInterface
      */
     private $searchManager;
 
     /**
-     * @param SearchManager $searchManager
+     * @param SearchManagerInterface $searchManager
      */
     public function __construct(SearchManagerInterface $searchManager)
     {

--- a/Search/Metadata/ClassMetadata.php
+++ b/Search/Metadata/ClassMetadata.php
@@ -107,11 +107,11 @@ class ClassMetadata extends BaseClassMetadata implements \Serializable
      *
      * @return string|null
      */
-    public function getReindexRepositoryMethod() 
+    public function getReindexRepositoryMethod()
     {
         return $this->repositoryMethod;
     }
-    
+
     /**
      * Set the repository method which should be used when reindexing.
      *

--- a/Search/Metadata/ClassMetadata.php
+++ b/Search/Metadata/ClassMetadata.php
@@ -107,11 +107,11 @@ class ClassMetadata extends BaseClassMetadata implements \Serializable
      *
      * @return string|null
      */
-    public function getReindexRepositoryMethod()
+    public function getReindexRepositoryMethod() 
     {
         return $this->repositoryMethod;
     }
-
+    
     /**
      * Set the repository method which should be used when reindexing.
      *

--- a/Search/Metadata/ClassMetadata.php
+++ b/Search/Metadata/ClassMetadata.php
@@ -25,6 +25,11 @@ class ClassMetadata extends BaseClassMetadata implements \Serializable
     private $indexMetadatas = [];
 
     /**
+     * @var string
+     */
+    private $repositoryMethod;
+
+    /**
      * Add an index metadata for the given context name.
      *
      * @param mixed $contextName
@@ -91,5 +96,29 @@ class ClassMetadata extends BaseClassMetadata implements \Serializable
         list($data, $indexMetadata) = unserialize($data);
         parent::unserialize($data);
         $this->indexMetadatas = unserialize($indexMetadata);
+    }
+
+    /**
+     * When reindexing, the repository method will be used to retrieve all of
+     * the entities which should be reindexed.
+     *
+     * NULL may be returned if the implementation should use a default method
+     * name. (e.g. `findAll` in Doctrine ORM).
+     *
+     * @return string|null
+     */
+    public function getReindexRepositoryMethod() 
+    {
+        return $this->repositoryMethod;
+    }
+    
+    /**
+     * Set the repository method which should be used when reindexing.
+     *
+     * @param string $repositoryMethod
+     */
+    public function setReindexRepositoryMethod($repositoryMethod)
+    {
+        $this->repositoryMethod = $repositoryMethod;
     }
 }

--- a/Search/Metadata/Driver/XmlDriver.php
+++ b/Search/Metadata/Driver/XmlDriver.php
@@ -97,6 +97,12 @@ class XmlDriver extends AbstractFileDriver implements DriverInterface
             ];
         }
 
+        if ($mapping->reindex) {
+            if ($mapping->reindex['repository-method']) {
+                 $classMetadata->setReindexRepositoryMethod($mapping->reindex['repository-method']);
+            }
+        }
+
         $indexMappings = array_merge(
             [
                 '_default' => $indexMapping,
@@ -120,6 +126,7 @@ class XmlDriver extends AbstractFileDriver implements DriverInterface
 
             $classMetadata->addIndexMetadata($contextName, $indexMetadata);
         }
+
 
         return $classMetadata;
     }

--- a/Search/Metadata/Driver/XmlDriver.php
+++ b/Search/Metadata/Driver/XmlDriver.php
@@ -99,7 +99,7 @@ class XmlDriver extends AbstractFileDriver implements DriverInterface
 
         if ($mapping->reindex) {
             if ($mapping->reindex['repository-method']) {
-                $classMetadata->setReindexRepositoryMethod($mapping->reindex['repository-method']);
+                 $classMetadata->setReindexRepositoryMethod($mapping->reindex['repository-method']);
             }
         }
 
@@ -126,6 +126,7 @@ class XmlDriver extends AbstractFileDriver implements DriverInterface
 
             $classMetadata->addIndexMetadata($contextName, $indexMetadata);
         }
+
 
         return $classMetadata;
     }

--- a/Search/Metadata/Driver/XmlDriver.php
+++ b/Search/Metadata/Driver/XmlDriver.php
@@ -99,7 +99,7 @@ class XmlDriver extends AbstractFileDriver implements DriverInterface
 
         if ($mapping->reindex) {
             if ($mapping->reindex['repository-method']) {
-                 $classMetadata->setReindexRepositoryMethod($mapping->reindex['repository-method']);
+                $classMetadata->setReindexRepositoryMethod((string) $mapping->reindex['repository-method']);
             }
         }
 
@@ -126,7 +126,6 @@ class XmlDriver extends AbstractFileDriver implements DriverInterface
 
             $classMetadata->addIndexMetadata($contextName, $indexMetadata);
         }
-
 
         return $classMetadata;
     }

--- a/Search/Metadata/Driver/XmlDriver.php
+++ b/Search/Metadata/Driver/XmlDriver.php
@@ -99,7 +99,7 @@ class XmlDriver extends AbstractFileDriver implements DriverInterface
 
         if ($mapping->reindex) {
             if ($mapping->reindex['repository-method']) {
-                 $classMetadata->setReindexRepositoryMethod($mapping->reindex['repository-method']);
+                $classMetadata->setReindexRepositoryMethod($mapping->reindex['repository-method']);
             }
         }
 
@@ -126,7 +126,6 @@ class XmlDriver extends AbstractFileDriver implements DriverInterface
 
             $classMetadata->addIndexMetadata($contextName, $indexMetadata);
         }
-
 
         return $classMetadata;
     }

--- a/Tests/Functional/Command/IndexRebuildCommandTest.php
+++ b/Tests/Functional/Command/IndexRebuildCommandTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the MassiveSearchBundle
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Massive\Bundle\SearchBundle\Tests\Functional;
+
+use Massive\Bundle\SearchBundle\Command\StatusCommand;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Massive\Bundle\SearchBundle\Command\IndexRebuildCommand;
+
+class IndexRebuildCommandTest extends BaseTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        $command = new IndexRebuildCommand();
+        $application = new Application($this->getContainer()->get('kernel'));
+        $command->setApplication($application);
+        $this->tester = new CommandTester($command);
+    }
+
+    /**
+     * This command just fires an event.
+     */
+    public function testCommand()
+    {
+        $this->tester->execute([
+        ]);
+
+        $this->assertEquals(0, $this->tester->getStatusCode());
+    }
+}

--- a/Tests/Functional/Command/IndexRebuildCommandTest.php
+++ b/Tests/Functional/Command/IndexRebuildCommandTest.php
@@ -11,10 +11,9 @@
 
 namespace Massive\Bundle\SearchBundle\Tests\Functional;
 
-use Massive\Bundle\SearchBundle\Command\StatusCommand;
+use Massive\Bundle\SearchBundle\Command\IndexRebuildCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
-use Massive\Bundle\SearchBundle\Command\IndexRebuildCommand;
 
 class IndexRebuildCommandTest extends BaseTestCase
 {

--- a/Tests/Functional/Command/IndexRebuildCommandTest.php
+++ b/Tests/Functional/Command/IndexRebuildCommandTest.php
@@ -32,8 +32,7 @@ class IndexRebuildCommandTest extends BaseTestCase
      */
     public function testCommand()
     {
-        $this->tester->execute([
-        ]);
+        $this->tester->execute([]);
 
         $this->assertEquals(0, $this->tester->getStatusCode());
     }

--- a/Tests/Functional/Command/IndexRebuildCommandTest.php
+++ b/Tests/Functional/Command/IndexRebuildCommandTest.php
@@ -11,9 +11,10 @@
 
 namespace Massive\Bundle\SearchBundle\Tests\Functional;
 
-use Massive\Bundle\SearchBundle\Command\IndexRebuildCommand;
+use Massive\Bundle\SearchBundle\Command\StatusCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+use Massive\Bundle\SearchBundle\Command\IndexRebuildCommand;
 
 class IndexRebuildCommandTest extends BaseTestCase
 {

--- a/Tests/Unit/Search/EventSubscriber/DoctrineOrmIndexRebuildSubscriberTest.php
+++ b/Tests/Unit/Search/EventSubscriber/DoctrineOrmIndexRebuildSubscriberTest.php
@@ -1,0 +1,155 @@
+<?php
+
+/*
+ * This file is part of the MassiveSearchBundle
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Massive\Bundle\SearchBundle\Unit\Search\EventSubscriber;
+
+use Doctrine\ORM\Event\LifecycleEventArgs;
+use Massive\Bundle\SearchBundle\Search\EventSubscriber\DoctrineOrmSubscriber;
+use Doctrine\Common\Persistence\Mapping\ClassMetadata as OrmMetadata;
+use Massive\Bundle\SearchBundle\Search\SearchManager;
+use Metadata\MetadataFactory;
+use Massive\Bundle\SearchBundle\Search\Metadata\ClassMetadata;
+use Metadata\ClassHierarchyMetadata;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Massive\Bundle\SearchBundle\Search\EventSubscriber\DoctrineOrmIndexRebuildSubscriber;
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Common\Persistence\Mapping\ClassMetadataFactory;
+use Prophecy\Argument;
+use Massive\Bundle\SearchBundle\Search\Event\IndexRebuildEvent;
+
+class DoctrineOrmIndexRebuildSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var BufferedOutput
+     */
+    private $output;
+
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
+
+    /**
+     * @var OrmMetadata
+     */
+    private $ormMetadataFactory;
+
+    /**
+     * @var OrmMetadata
+     */
+    private $ormMetadata;
+
+    /**
+     * @var MetadataFactory
+     */
+    private $searchMetadataFactory;
+
+    /**
+     * @var ClassHierarchyMetadata
+     */
+    private $searchHierarchy;
+
+    /**
+     * @var ClassMetadata
+     */
+    private $searchMetadata;
+
+    /**
+     * @var SearchManager
+     */
+    private $searchManager;
+
+    /**
+     * @var DoctrineOrmIndexRebuildSubscriber
+     */
+    private $subscriber;
+
+
+    public function setUp()
+    {
+        $this->output = new BufferedOutput();
+        $this->objectManager = $this->prophesize(ObjectManager::class);
+        $this->ormMetadataFactory = $this->prophesize(ClassMetadataFactory::class);
+        $this->ormMetadata = $this->prophesize(OrmMetadata::class);
+        $this->searchMetadataFactory = $this->prophesize(MetadataFactory::class);
+        $this->searchHierarchy = $this->prophesize(ClassHierarchyMetadata::class);
+        $this->searchMetadata = $this->prophesize(ClassMetadata::class);
+        $this->searchManager = $this->prophesize(SearchManager::class);
+
+        $this->subscriber = new DoctrineOrmIndexRebuildSubscriber(
+            $this->objectManager->reveal(),
+            $this->searchMetadataFactory->reveal(),
+            $this->searchManager->reveal()
+        );
+
+    }
+
+    /**
+     * It should call the named repository method if requested
+     */
+    public function testRepositoryMethod()
+    {
+        $this->prepareReindex();
+
+        $this->searchMetadata->getReindexRepositoryMethod()->willReturn('foobar');
+        $this->searchManager->index(Argument::type('stdClass'))->shouldBeCalledTimes(1);
+
+        $event = $this->createEvent(null, false);
+        $this->subscriber->rebuildIndex($event);
+    }
+
+    /**
+     * It should throw an exception if the repository method does not exist
+     *
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Repository method "barfoo" does not exist
+     */
+    public function testRepositoryMethodNotExists()
+    {
+        $this->prepareReindex();
+
+        $this->searchMetadata->getReindexRepositoryMethod()->willReturn('barfoo');
+
+        $event = $this->createEvent(null, false);
+        $this->subscriber->rebuildIndex($event);
+    }
+
+    private function createEvent($filter, $purge)
+    {
+        return new IndexRebuildEvent(
+            $filter,
+            $purge,
+            $this->output
+        );
+    }
+
+    private function prepareReindex()
+    {
+        $this->objectManager->getMetadataFactory()->willReturn($this->ormMetadataFactory);
+        $this->searchHierarchy->getOutsideClassMetadata()->willReturn($this->searchMetadata->reveal());
+        $this->ormMetadataFactory->getAllMetadata()->willReturn(array(
+            $this->ormMetadata->reveal()
+        ));
+        $this->ormMetadata->name = 'stdClass';
+        $this->searchMetadata->name = 'stdClass';
+        $this->searchMetadataFactory->getMetadataForClass('stdClass')->willReturn($this->searchHierarchy->reveal());
+
+        $this->objectManager->getRepository('stdClass')->willReturn(new TestRepository());
+    }
+}
+
+class TestRepository
+{
+    public function foobar()
+    {
+        return array(new \stdClass);
+    }
+}

--- a/Tests/Unit/Search/EventSubscriber/DoctrineOrmIndexRebuildSubscriberTest.php
+++ b/Tests/Unit/Search/EventSubscriber/DoctrineOrmIndexRebuildSubscriberTest.php
@@ -11,17 +11,19 @@
 
 namespace Massive\Bundle\SearchBundle\Unit\Search\EventSubscriber;
 
+use Doctrine\ORM\Event\LifecycleEventArgs;
+use Massive\Bundle\SearchBundle\Search\EventSubscriber\DoctrineOrmSubscriber;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata as OrmMetadata;
-use Doctrine\Common\Persistence\Mapping\ClassMetadataFactory;
-use Doctrine\Common\Persistence\ObjectManager;
-use Massive\Bundle\SearchBundle\Search\Event\IndexRebuildEvent;
-use Massive\Bundle\SearchBundle\Search\EventSubscriber\DoctrineOrmIndexRebuildSubscriber;
-use Massive\Bundle\SearchBundle\Search\Metadata\ClassMetadata;
 use Massive\Bundle\SearchBundle\Search\SearchManager;
-use Metadata\ClassHierarchyMetadata;
 use Metadata\MetadataFactory;
-use Prophecy\Argument;
+use Massive\Bundle\SearchBundle\Search\Metadata\ClassMetadata;
+use Metadata\ClassHierarchyMetadata;
 use Symfony\Component\Console\Output\BufferedOutput;
+use Massive\Bundle\SearchBundle\Search\EventSubscriber\DoctrineOrmIndexRebuildSubscriber;
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Common\Persistence\Mapping\ClassMetadataFactory;
+use Prophecy\Argument;
+use Massive\Bundle\SearchBundle\Search\Event\IndexRebuildEvent;
 
 class DoctrineOrmIndexRebuildSubscriberTest extends \PHPUnit_Framework_TestCase
 {
@@ -70,6 +72,7 @@ class DoctrineOrmIndexRebuildSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     private $subscriber;
 
+
     public function setUp()
     {
         $this->output = new BufferedOutput();
@@ -86,10 +89,11 @@ class DoctrineOrmIndexRebuildSubscriberTest extends \PHPUnit_Framework_TestCase
             $this->searchMetadataFactory->reveal(),
             $this->searchManager->reveal()
         );
+
     }
 
     /**
-     * It should call the named repository method if requested.
+     * It should call the named repository method if requested
      */
     public function testRepositoryMethod()
     {
@@ -105,7 +109,7 @@ class DoctrineOrmIndexRebuildSubscriberTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * It should throw an exception if the repository method does not exist.
+     * It should throw an exception if the repository method does not exist
      *
      * @expectedException InvalidArgumentException
      * @expectedExceptionMessage Repository method "barfoo" does not exist
@@ -133,9 +137,9 @@ class DoctrineOrmIndexRebuildSubscriberTest extends \PHPUnit_Framework_TestCase
     {
         $this->objectManager->getMetadataFactory()->willReturn($this->ormMetadataFactory);
         $this->searchHierarchy->getOutsideClassMetadata()->willReturn($this->searchMetadata->reveal());
-        $this->ormMetadataFactory->getAllMetadata()->willReturn([
-            $this->ormMetadata->reveal(),
-        ]);
+        $this->ormMetadataFactory->getAllMetadata()->willReturn(array(
+            $this->ormMetadata->reveal()
+        ));
         $this->ormMetadata->name = 'stdClass';
         $this->searchMetadata->name = 'stdClass';
         $this->searchMetadataFactory->getMetadataForClass('stdClass')->willReturn($this->searchHierarchy->reveal());
@@ -148,6 +152,6 @@ class TestRepository
 {
     public function foobar()
     {
-        return [new \stdClass()];
+        return array(new \stdClass);
     }
 }

--- a/Tests/Unit/Search/EventSubscriber/DoctrineOrmIndexRebuildSubscriberTest.php
+++ b/Tests/Unit/Search/EventSubscriber/DoctrineOrmIndexRebuildSubscriberTest.php
@@ -11,19 +11,17 @@
 
 namespace Massive\Bundle\SearchBundle\Unit\Search\EventSubscriber;
 
-use Doctrine\ORM\Event\LifecycleEventArgs;
-use Massive\Bundle\SearchBundle\Search\EventSubscriber\DoctrineOrmSubscriber;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata as OrmMetadata;
-use Massive\Bundle\SearchBundle\Search\SearchManager;
-use Metadata\MetadataFactory;
-use Massive\Bundle\SearchBundle\Search\Metadata\ClassMetadata;
-use Metadata\ClassHierarchyMetadata;
-use Symfony\Component\Console\Output\BufferedOutput;
-use Massive\Bundle\SearchBundle\Search\EventSubscriber\DoctrineOrmIndexRebuildSubscriber;
-use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Persistence\Mapping\ClassMetadataFactory;
-use Prophecy\Argument;
+use Doctrine\Common\Persistence\ObjectManager;
 use Massive\Bundle\SearchBundle\Search\Event\IndexRebuildEvent;
+use Massive\Bundle\SearchBundle\Search\EventSubscriber\DoctrineOrmIndexRebuildSubscriber;
+use Massive\Bundle\SearchBundle\Search\Metadata\ClassMetadata;
+use Massive\Bundle\SearchBundle\Search\SearchManager;
+use Metadata\ClassHierarchyMetadata;
+use Metadata\MetadataFactory;
+use Prophecy\Argument;
+use Symfony\Component\Console\Output\BufferedOutput;
 
 class DoctrineOrmIndexRebuildSubscriberTest extends \PHPUnit_Framework_TestCase
 {
@@ -72,7 +70,6 @@ class DoctrineOrmIndexRebuildSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     private $subscriber;
 
-
     public function setUp()
     {
         $this->output = new BufferedOutput();
@@ -89,11 +86,10 @@ class DoctrineOrmIndexRebuildSubscriberTest extends \PHPUnit_Framework_TestCase
             $this->searchMetadataFactory->reveal(),
             $this->searchManager->reveal()
         );
-
     }
 
     /**
-     * It should call the named repository method if requested
+     * It should call the named repository method if requested.
      */
     public function testRepositoryMethod()
     {
@@ -107,7 +103,7 @@ class DoctrineOrmIndexRebuildSubscriberTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * It should throw an exception if the repository method does not exist
+     * It should throw an exception if the repository method does not exist.
      *
      * @expectedException InvalidArgumentException
      * @expectedExceptionMessage Repository method "barfoo" does not exist
@@ -135,9 +131,9 @@ class DoctrineOrmIndexRebuildSubscriberTest extends \PHPUnit_Framework_TestCase
     {
         $this->objectManager->getMetadataFactory()->willReturn($this->ormMetadataFactory);
         $this->searchHierarchy->getOutsideClassMetadata()->willReturn($this->searchMetadata->reveal());
-        $this->ormMetadataFactory->getAllMetadata()->willReturn(array(
-            $this->ormMetadata->reveal()
-        ));
+        $this->ormMetadataFactory->getAllMetadata()->willReturn([
+            $this->ormMetadata->reveal(),
+        ]);
         $this->ormMetadata->name = 'stdClass';
         $this->searchMetadata->name = 'stdClass';
         $this->searchMetadataFactory->getMetadataForClass('stdClass')->willReturn($this->searchHierarchy->reveal());
@@ -150,6 +146,6 @@ class TestRepository
 {
     public function foobar()
     {
-        return array(new \stdClass);
+        return [new \stdClass()];
     }
 }

--- a/Tests/Unit/Search/EventSubscriber/DoctrineOrmIndexRebuildSubscriberTest.php
+++ b/Tests/Unit/Search/EventSubscriber/DoctrineOrmIndexRebuildSubscriberTest.php
@@ -100,6 +100,8 @@ class DoctrineOrmIndexRebuildSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $event = $this->createEvent(null, false);
         $this->subscriber->rebuildIndex($event);
+
+        $this->assertContains('1 entities indexed', $this->output->fetch());
     }
 
     /**

--- a/Tests/Unit/Search/EventSubscriber/DoctrineOrmIndexRebuildSubscriberTest.php
+++ b/Tests/Unit/Search/EventSubscriber/DoctrineOrmIndexRebuildSubscriberTest.php
@@ -11,19 +11,16 @@
 
 namespace Massive\Bundle\SearchBundle\Unit\Search\EventSubscriber;
 
-use Doctrine\ORM\Event\LifecycleEventArgs;
-use Massive\Bundle\SearchBundle\Search\EventSubscriber\DoctrineOrmSubscriber;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata as OrmMetadata;
-use Massive\Bundle\SearchBundle\Search\SearchManager;
-use Metadata\MetadataFactory;
-use Massive\Bundle\SearchBundle\Search\Metadata\ClassMetadata;
-use Metadata\ClassHierarchyMetadata;
-use Symfony\Component\Console\Output\BufferedOutput;
-use Massive\Bundle\SearchBundle\Search\EventSubscriber\DoctrineOrmIndexRebuildSubscriber;
 use Doctrine\Common\Persistence\ObjectManager;
-use Doctrine\Common\Persistence\Mapping\ClassMetadataFactory;
-use Prophecy\Argument;
 use Massive\Bundle\SearchBundle\Search\Event\IndexRebuildEvent;
+use Massive\Bundle\SearchBundle\Search\EventSubscriber\DoctrineOrmIndexRebuildSubscriber;
+use Massive\Bundle\SearchBundle\Search\Metadata\ClassMetadata;
+use Massive\Bundle\SearchBundle\Search\SearchManager;
+use Metadata\ClassHierarchyMetadata;
+use Metadata\MetadataFactory;
+use Prophecy\Argument;
+use Symfony\Component\Console\Output\BufferedOutput;
 
 class DoctrineOrmIndexRebuildSubscriberTest extends \PHPUnit_Framework_TestCase
 {
@@ -72,7 +69,6 @@ class DoctrineOrmIndexRebuildSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     private $subscriber;
 
-
     public function setUp()
     {
         $this->output = new BufferedOutput();
@@ -89,11 +85,10 @@ class DoctrineOrmIndexRebuildSubscriberTest extends \PHPUnit_Framework_TestCase
             $this->searchMetadataFactory->reveal(),
             $this->searchManager->reveal()
         );
-
     }
 
     /**
-     * It should call the named repository method if requested
+     * It should call the named repository method if requested.
      */
     public function testRepositoryMethod()
     {
@@ -109,7 +104,7 @@ class DoctrineOrmIndexRebuildSubscriberTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * It should throw an exception if the repository method does not exist
+     * It should throw an exception if the repository method does not exist.
      *
      * @expectedException InvalidArgumentException
      * @expectedExceptionMessage Repository method "barfoo" does not exist
@@ -137,9 +132,9 @@ class DoctrineOrmIndexRebuildSubscriberTest extends \PHPUnit_Framework_TestCase
     {
         $this->objectManager->getMetadataFactory()->willReturn($this->ormMetadataFactory);
         $this->searchHierarchy->getOutsideClassMetadata()->willReturn($this->searchMetadata->reveal());
-        $this->ormMetadataFactory->getAllMetadata()->willReturn(array(
-            $this->ormMetadata->reveal()
-        ));
+        $this->ormMetadataFactory->getAllMetadata()->willReturn([
+            $this->ormMetadata->reveal(),
+        ]);
         $this->ormMetadata->name = 'stdClass';
         $this->searchMetadata->name = 'stdClass';
         $this->searchMetadataFactory->getMetadataForClass('stdClass')->willReturn($this->searchHierarchy->reveal());
@@ -152,6 +147,6 @@ class TestRepository
 {
     public function foobar()
     {
-        return array(new \stdClass);
+        return [new \stdClass()];
     }
 }

--- a/Tests/Unit/Search/EventSubscriber/DoctrineOrmIndexRebuildSubscriberTest.php
+++ b/Tests/Unit/Search/EventSubscriber/DoctrineOrmIndexRebuildSubscriberTest.php
@@ -76,13 +76,13 @@ class DoctrineOrmIndexRebuildSubscriberTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->output = new BufferedOutput();
-        $this->objectManager = $this->prophesize(ObjectManager::class);
-        $this->ormMetadataFactory = $this->prophesize(ClassMetadataFactory::class);
-        $this->ormMetadata = $this->prophesize(OrmMetadata::class);
-        $this->searchMetadataFactory = $this->prophesize(MetadataFactory::class);
-        $this->searchHierarchy = $this->prophesize(ClassHierarchyMetadata::class);
-        $this->searchMetadata = $this->prophesize(ClassMetadata::class);
-        $this->searchManager = $this->prophesize(SearchManager::class);
+        $this->objectManager = $this->prophesize('Doctrine\Common\Persistence\ObjectManager');
+        $this->ormMetadataFactory = $this->prophesize('Doctrine\Common\Persistence\Mapping\ClassMetadataFactory');
+        $this->ormMetadata = $this->prophesize('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $this->searchMetadataFactory = $this->prophesize('Metadata\MetadataFactory');
+        $this->searchHierarchy = $this->prophesize('Metadata\ClassHierarchyMetadata');
+        $this->searchMetadata = $this->prophesize('Massive\Bundle\SearchBundle\Search\Metadata\ClassMetadata');
+        $this->searchManager = $this->prophesize('Massive\Bundle\SearchBundle\Search\SearchManager');
 
         $this->subscriber = new DoctrineOrmIndexRebuildSubscriber(
             $this->objectManager->reveal(),

--- a/Tests/Unit/Search/Metadata/Driver/XmlDriverTest.php
+++ b/Tests/Unit/Search/Metadata/Driver/XmlDriverTest.php
@@ -2,8 +2,8 @@
 
 namespace Massive\Bundle\SearchBundle\Tests\Unit\Search\Metadata\Driver;
 
-use Massive\Bundle\SearchBundle\Search\Factory;
 use Massive\Bundle\SearchBundle\Search\Metadata\Driver\XmlDriver;
+use Massive\Bundle\SearchBundle\Search\Factory;
 
 class XmlDriverTest extends \PHPUnit_Framework_TestCase
 {
@@ -28,7 +28,7 @@ class XmlDriverTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * It should load metadata from a file.
+     * It should load metadata from a file
      */
     public function testLoadMetadataFromFile()
     {
@@ -64,7 +64,7 @@ EOT
     }
 
     /**
-     * It should allow the specification of reindex directives.
+     * It should allow the specification of reindex directives
      */
     public function testReindexDirectives()
     {
@@ -91,14 +91,12 @@ EOT
     {
         $path = $this->getTmpMappingPath();
         file_put_contents($path, $mapping);
-
         return $path;
     }
 
     private function getTmpMappingPath()
     {
         $tempDir = sys_get_temp_dir();
-
         return $tempDir . '/' . self::TMP_FILE;
     }
 }

--- a/Tests/Unit/Search/Metadata/Driver/XmlDriverTest.php
+++ b/Tests/Unit/Search/Metadata/Driver/XmlDriverTest.php
@@ -2,8 +2,8 @@
 
 namespace Massive\Bundle\SearchBundle\Tests\Unit\Search\Metadata\Driver;
 
-use Massive\Bundle\SearchBundle\Search\Metadata\Driver\XmlDriver;
 use Massive\Bundle\SearchBundle\Search\Factory;
+use Massive\Bundle\SearchBundle\Search\Metadata\Driver\XmlDriver;
 
 class XmlDriverTest extends \PHPUnit_Framework_TestCase
 {
@@ -28,7 +28,7 @@ class XmlDriverTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * It should load metadata from a file
+     * It should load metadata from a file.
      */
     public function testLoadMetadataFromFile()
     {
@@ -64,7 +64,7 @@ EOT
     }
 
     /**
-     * It should allow the specification of reindex directives
+     * It should allow the specification of reindex directives.
      */
     public function testReindexDirectives()
     {
@@ -91,12 +91,14 @@ EOT
     {
         $path = $this->getTmpMappingPath();
         file_put_contents($path, $mapping);
+
         return $path;
     }
 
     private function getTmpMappingPath()
     {
         $tempDir = sys_get_temp_dir();
+
         return $tempDir . '/' . self::TMP_FILE;
     }
 }

--- a/Tests/Unit/Search/Metadata/Driver/XmlDriverTest.php
+++ b/Tests/Unit/Search/Metadata/Driver/XmlDriverTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Massive\Bundle\SearchBundle\Tests\Unit\Search\Metadata\Driver;
+
+use Massive\Bundle\SearchBundle\Search\Metadata\Driver\XmlDriver;
+use Massive\Bundle\SearchBundle\Search\Factory;
+
+class XmlDriverTest extends \PHPUnit_Framework_TestCase
+{
+    const TMP_FILE = 'mapping_test';
+
+    public function setUp()
+    {
+        $factory = new Factory();
+        $this->locator = $this->prophesize('Metadata\Driver\FileLocatorInterface');
+        $this->driver = new XmlDriver(
+            $factory,
+            $this->locator->reveal()
+        );
+    }
+
+    public function tearDown()
+    {
+        $mappingPath = $this->getTmpMappingPath();
+        if (file_exists($mappingPath)) {
+            unlink($mappingPath);
+        }
+    }
+
+    /**
+     * It should load metadata from a file
+     */
+    public function testLoadMetadataFromFile()
+    {
+        $path = $this->createMapping(<<<EOT
+<massive-search-mapping xmlns="http://massiveart.com/schema/dic/massive-search-mapping">
+
+    <mapping class="stdClass">
+        <index name="index_bicycle"/>
+        <id property="id"/>
+        <title property="title" />
+        <category name="transport" />
+        <fields>
+            <field name="title" expr="object.title" type="string" />
+        </fields>
+    </mapping>
+
+</massive-search-mapping>
+EOT
+    );
+        $reflection = new \ReflectionClass('stdClass');
+        $metadata = $this->driver->loadMetadataFromFile($reflection, $path);
+
+        $this->assertInstanceOf('Massive\Bundle\SearchBundle\Search\Metadata\ClassMetadata', $metadata);
+        $indexMetadatas = $metadata->getIndexMetadatas();
+        $this->assertCount(1, $indexMetadatas);
+        $indexMetadata = reset($indexMetadatas);
+        $this->assertEquals('index_bicycle', $indexMetadata->getIndexName());
+        $this->assertInstanceOf('Massive\Bundle\SearchBundle\Search\Metadata\Field\Property', $indexMetadata->getIdField());
+        $this->assertEquals('id', $indexMetadata->getIdField()->getProperty());
+        $this->assertEquals('title', $indexMetadata->getTitleField()->getProperty());
+        $this->assertEquals('transport', $indexMetadata->getCategoryName());
+        $this->assertCount(1, $indexMetadata->getFieldMapping());
+    }
+
+    /**
+     * It should allow the specification of reindex directives
+     */
+    public function testReindexDirectives()
+    {
+        $path = $this->createMapping(<<<EOT
+<massive-search-mapping xmlns="http://massiveart.com/schema/dic/massive-search-mapping">
+
+    <mapping class="stdClass">
+        <index name="foo"/>
+        <id property="id"/>
+        <title property="foo" />
+        <reindex repository-method="findLatest" />
+        <fields/>
+    </mapping>
+
+</massive-search-mapping>
+EOT
+    );
+        $reflection = new \ReflectionClass('stdClass');
+        $metadata = $this->driver->loadMetadataFromFile($reflection, $path);
+        $this->assertEquals('findLatest', $metadata->getReindexRepositoryMethod());
+    }
+
+    private function createMapping($mapping)
+    {
+        $path = $this->getTmpMappingPath();
+        file_put_contents($path, $mapping);
+        return $path;
+    }
+
+    private function getTmpMappingPath()
+    {
+        $tempDir = sys_get_temp_dir();
+        return $tempDir . '/' . self::TMP_FILE;
+    }
+}

--- a/Tests/Unit/Search/Metadata/Driver/metadata/stdClass.xml
+++ b/Tests/Unit/Search/Metadata/Driver/metadata/stdClass.xml
@@ -1,0 +1,13 @@
+<massive-search-mapping xmlns="http://massiveart.com/schema/dic/massive-search-mapping">
+
+    <mapping class="stdClass">
+        <index name="index_bicycle"/>
+        <id property="id"/>
+        <title property="title" />
+        <category name="transport" />
+        <fields>
+            <field name="title" expr="object.title" type="string" />
+        </fields>
+    </mapping>
+
+</massive-search-mapping>

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "behat/behat": "~3.0.0",
         "behat/web-api-extension": "~1.0@dev",
         "behat/symfony2-extension": "~2.0@dev",
-        "dantleech/phpbench": "~1.0"
+        "phpbench/phpbench": "~1.0"
     },
     "suggest": {
         "zendframework/zendsearch": "To use the PHP based Zend Search library (based on Lucene)",


### PR DESCRIPTION
This PR introduces a way to specify which method to use on the entity repository when retrieving entities which should be reindexed.

This provides a way to only reindex certain objects for certain class mappings.

````xml
<?xml version="1.0" ?>
<mapping ...>
    <reindex repository-method="findOnlySomeStuff" />
</mapping>
````

NOTE: This PR only introduces the `repository-method` mapping, but it follows that there can be introduced a `repository-id` mapping which specifies a service which could be used to instead of the, in this case, default ORM repository.