### PR TITLE
added missing passing of options to PrefixDecorator

### DIFF
--- a/Behat/SearchManagerContext.php
+++ b/Behat/SearchManagerContext.php
@@ -310,7 +310,7 @@ class SearchManagerContext implements SnippetAcceptingContext, KernelAwareContex
             $this->kernel->getContainer()->get('massive_search.metadata.provider.chain'),
             $this->kernel->getContainer()->get('massive_search.object_to_document_converter'),
             $this->kernel->getContainer()->get('event_dispatcher'),
-            $this->kernel->getContainer()->get('massive_search.localization_decorator'),
+            $this->kernel->getContainer()->get('massive_search.index_name_decorator.default'),
             $this->kernel->getContainer()->get('massive_search.metadata.field_evaluator')
         );
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG
 =========
 
 * dev-develop
+    * BUGFIX  #70 Added missing passing of options to PrefixDecorator
     * FEATURE #67 Added support for sort/order for elastic search
     * FEATURE #68 Introduce decorators for index names and introduce prefixes
     * FEATURE #66 Added support for date

--- a/Search/Decorator/PrefixDecorator.php
+++ b/Search/Decorator/PrefixDecorator.php
@@ -65,7 +65,7 @@ class PrefixDecorator implements IndexNameDecoratorInterface
         }
 
         $undecoratedIndexName = $this->removePrefix($decoratedIndexName);
-        if (!$this->decorator->isVariant($indexName, $undecoratedIndexName)) {
+        if (!$this->decorator->isVariant($indexName, $undecoratedIndexName, $options)) {
             return false;
         }
 

--- a/Tests/Features/localized.feature
+++ b/Tests/Features/localized.feature
@@ -52,7 +52,8 @@ Feature: Search Manager
             { "id": 1, "title": "Giraffe", "body": "Long neck", "date": "2015-01-01", "url": "http://foo", "locale": "fr", "image": "foo.png" },
             { "id": 2, "title": "Lion", "body": "Big mane", "date": "2015-01-01", "url": "http://lion.com", "locale": "fr", "image": "foo.png" },
             { "id": 4, "title": "Lion 2", "body": "Big mane", "date": "2015-01-01", "url": "http://lion.com", "locale": "fr", "image": "foo.png" },
-            { "id": 6, "title": "German Hyena", "body": "Laughs", "date": "2015-01-01", "url": "http://hyena.com", "locale": "de", "image": "foo.png" }
+            { "id": 6, "title": "German Hyena", "body": "Laughs", "date": "2015-01-01", "url": "http://hyena.com", "locale": "de", "image": "foo.png" },
+            { "id": 7, "title": "Giraffe", "body": "Long neck", "date": "2015-01-01", "url": "http://foo", "locale": "de", "image": "foo.png" }
         ]
         """
         When I search for "<animal>" in locale "<locale>"

--- a/Tests/Unit/Search/Decorator/PrefixDecoratorTest.php
+++ b/Tests/Unit/Search/Decorator/PrefixDecoratorTest.php
@@ -67,9 +67,10 @@ class PrefixDecoratorTest extends \PHPUnit_Framework_TestCase
 
     public function testIsVariant()
     {
-        $this->otherDecorator->isVariant('my_index', 'my_index')->willReturn(true);
+        $options = ['option' => 'value'];
+        $this->otherDecorator->isVariant('my_index', 'my_index', $options)->willReturn(true);
         $this->otherDecorator->undecorate('my_index')->willReturn('my_index');
-        $this->assertTrue($this->prefixDecorator->isVariant('my_index', 'prefix_my_index'));
+        $this->assertTrue($this->prefixDecorator->isVariant('my_index', 'prefix_my_index', $options));
     }
 
     public function testIsVariantWithWrongPrefix()


### PR DESCRIPTION
Causes the search to search through all locales instead of only one.

__tasks:__

- [x] test coverage

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| Related PRs      | none
| BC breaks        | none
| Documentation PR | none