### PR TITLE
Removed typehint to avoid failing testcases in php7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ sudo: false
 php:
   - 5.5
   - 5.6
+  - 7.0
 
 before_script:
     - composer selfupdate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG
 =========
 
+* dev-develop
+    * BUGFIX  #73 Removed typehint to avoid failing testcases in php7
+
 * 0.12.0 (2015-12-11)
     * HOTFIX  #69 Improve memory usage of rebuilding search indexes
     * HOTFIX  #72 Fixed null date-value

--- a/Search/Field.php
+++ b/Search/Field.php
@@ -165,7 +165,7 @@ class Field
      *
      * @param bool $stored
      */
-    public function setStored(bool $stored)
+    public function setStored($stored)
     {
         $this->stored = $stored;
     }
@@ -195,7 +195,7 @@ class Field
      *
      * @param bool $aggregate
      */
-    public function setAggregate(bool $aggregate)
+    public function setAggregate($aggregate)
     {
         $this->aggregate = $aggregate;
     }

--- a/Tests/Unit/DependencyInjection/MassiveSearchExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/MassiveSearchExtensionTest.php
@@ -132,7 +132,7 @@ class MassiveSearchExtensionTest extends AbstractExtensionTestCase
     /**
      * @dataProvider providePersistence
      */
-    public function testPersistence($persistenceName = null, $expectedServices)
+    public function testPersistence($persistenceName, $expectedServices)
     {
         $config = [];
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "zendframework/zend-stdlib": "2.3.1 as 2.0.0rc5",
         "zendframework/zendsearch": "2.*@dev",
         "elasticsearch/elasticsearch": "~1.3",
-        "symfony-cmf/testing": "~1.2",
+        "symfony-cmf/testing": "dev-master",
         "symfony/symfony": "~2.6",
         "matthiasnoback/symfony-dependency-injection-test": "0.7.1",
         "doctrine/doctrine-bundle": "~1.3",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "zendframework/zend-stdlib": "2.3.1 as 2.0.0rc5",
-        "zendframework/zendsearch": "2.*",
+        "zendframework/zendsearch": "2.*@dev",
         "elasticsearch/elasticsearch": "~1.3",
         "symfony-cmf/testing": "~1.2",
         "symfony/symfony": "~2.6",
@@ -26,7 +26,8 @@
         "behat/behat": "~3.0.0",
         "behat/web-api-extension": "~1.0@dev",
         "behat/symfony2-extension": "~2.0@dev",
-        "phpbench/phpbench": "~1.0"
+        "phpbench/phpbench": "~1.0@dev",
+        "phpbench/tabular": "@dev"
     },
     "suggest": {
         "zendframework/zendsearch": "To use the PHP based Zend Search library (based on Lucene)",
@@ -38,7 +39,6 @@
             "Massive\\Bundle\\SearchBundle\\": ""
         }
     },
-    "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
             "dev-develop": "1.0-dev"


### PR DESCRIPTION
If scalar typehints are used prophecy generates wrong php code for mock classes. they will break the testcases (see https://travis-ci.org/sulu-io/sulu/jobs/102034955#L1028).

__informations:__

| q                | a
| ---------------- | ---
| Fixed tickets    | none
| Related PRs      | none
| BC breaks        | none
| Documentation PR | none