### PR TITLE
added composer script handler for creating zend lucene directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG
 =========
 
 * dev-develop
+    * FEATURE #80 Added composer handler for creating zend lucene directory
     * FEATURE #74 Added support for resuming interupted reindexing tasks
     * FEATURE #74 Deprecated `massive:search:index:rebuild` command in favor
                   of `massive:search:reindex`

--- a/Command/InitCommand.php
+++ b/Command/InitCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the MassiveSearchBundle
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Massive\Bundle\SearchBundle\Command;
+
+use Massive\Bundle\SearchBundle\Search\AdapterInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Initializes the search adapter.
+ */
+class InitCommand extends Command
+{
+    /**
+     * @var AdapterInterface
+     */
+    private $adapter;
+
+    public function __construct(AdapterInterface $adapter)
+    {
+        parent::__construct();
+        $this->adapter = $adapter;
+    }
+
+    public function configure()
+    {
+        $this->setName('massive:search:init');
+        $this->setDescription('Initializes the search bundle');
+        $this->setHelp('This command will simply call the initialize method of the currently active search adapter.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->adapter->initialize();
+    }
+}

--- a/Composer/SearchScriptHandler.php
+++ b/Composer/SearchScriptHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the MassiveSearchBundle
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Massive\Bundle\SearchBundle\Composer;
+
+use Composer\Script\CommandEvent;
+use Sensio\Bundle\DistributionBundle\Composer\ScriptHandler;
+
+class SearchScriptHandler extends ScriptHandler
+{
+    /**
+     * @param $event CommandEvent A instance
+     */
+    public static function initBundle(CommandEvent $event)
+    {
+        $options = parent::getOptions($event);
+        $consoleDir = isset($options['symfony-bin-dir']) ? $options['symfony-bin-dir'] : $options['symfony-app-dir'];
+
+        parent::executeCommand(
+            $event,
+            $consoleDir,
+            'massive:search:init'
+        );
+    }
+}

--- a/Resources/config/adapter_zendlucene.xml
+++ b/Resources/config/adapter_zendlucene.xml
@@ -7,6 +7,7 @@
                  class="Massive\Bundle\SearchBundle\Search\Adapter\ZendLuceneAdapter">
             <argument type="service" id="massive_search.factory"/>
             <argument>%massive_search.adapter.zend_lucene.basepath%</argument>
+            <argument type="service" id="filesystem"/>
             <argument>%massive_search.adapter.zend_lucene.hide_index_exception%</argument>
             <argument>%massive_search.adapter.zend_lucene.encoding%</argument>
         </service>

--- a/Resources/config/command.xml
+++ b/Resources/config/command.xml
@@ -4,6 +4,11 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <service id="massive_search.command.init" class="Massive\Bundle\SearchBundle\Command\InitCommand">
+            <argument type="service" id="massive_search.adapter" />
+            <tag name="console.command" />
+        </service>
+
         <service id="massive_search.command.status" class="Massive\Bundle\SearchBundle\Command\StatusCommand">
             <argument type="service" id="massive_search.search_manager" />
             <tag name="console.command" />

--- a/Search/Adapter/ElasticSearchAdapter.php
+++ b/Search/Adapter/ElasticSearchAdapter.php
@@ -285,4 +285,13 @@ class ElasticSearchAdapter implements AdapterInterface
 
         return substr(str_replace('\\', '_', $class), 1);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function initialize()
+    {
+        // currently the elastic search adapter does not need any initialization
+        // might make sense to create some schema stuff here
+    }
 }

--- a/Search/Adapter/TestAdapter.php
+++ b/Search/Adapter/TestAdapter.php
@@ -145,4 +145,12 @@ class TestAdapter implements AdapterInterface
     {
         return [];
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function initialize()
+    {
+        // nothing to do here
+    }
 }

--- a/Search/Adapter/ZendLuceneAdapter.php
+++ b/Search/Adapter/ZendLuceneAdapter.php
@@ -55,6 +55,11 @@ class ZendLuceneAdapter implements AdapterInterface
     private $basePath;
 
     /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
      * @var bool
      */
     private $hideIndexException;
@@ -67,17 +72,20 @@ class ZendLuceneAdapter implements AdapterInterface
     /**
      * @param Factory $factory
      * @param string $basePath Base filesystem path for the index
+     * @param Filesystem $filesystem
      * @param bool $hideIndexException
      * @param null $encoding
      */
     public function __construct(
         Factory $factory,
         $basePath,
+        Filesystem $filesystem,
         $hideIndexException = false,
         $encoding = null
     ) {
         $this->factory = $factory;
         $this->basePath = $basePath;
+        $this->filesystem = $filesystem;
         $this->hideIndexException = $hideIndexException;
         $this->encoding = $encoding;
 
@@ -423,5 +431,15 @@ class ZendLuceneAdapter implements AdapterInterface
                 $field->getName()
             )
         );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function initialize()
+    {
+        if (!$this->filesystem->exists($this->basePath)) {
+            $this->filesystem->mkdir($this->basePath);
+        }
     }
 }

--- a/Search/AdapterInterface.php
+++ b/Search/AdapterInterface.php
@@ -65,4 +65,9 @@ interface AdapterInterface
      * {@inheritdoc}
      */
     public function flush(array $indexNames);
+
+    /**
+     * Initializes whatever is required for this adapter.
+     */
+    public function initialize();
 }

--- a/Search/Event/IndexEvent.php
+++ b/Search/Event/IndexEvent.php
@@ -29,7 +29,7 @@ class IndexEvent extends Event
 
     /**
      * The object, which should be indexed.
-     * 
+     *
      * @return object
      */
     public function getSubject()

--- a/Search/EventListener/DeindexListener.php
+++ b/Search/EventListener/DeindexListener.php
@@ -31,7 +31,7 @@ class DeindexListener
 
     /**
      * Deindex subject from event.
-     * 
+     *
      * @param DeindexEvent $event
      */
     public function onDeindex(DeindexEvent $event)

--- a/Tests/Functional/Command/InitCommandTest.php
+++ b/Tests/Functional/Command/InitCommandTest.php
@@ -11,11 +11,11 @@
 
 namespace Massive\Bundle\SearchBundle\Tests\Functional;
 
-class StatusCommandTest extends BaseTestCase
+class InitCommandTest extends BaseTestCase
 {
     public function testCommand()
     {
-        $command = $this->getCommand('phpcr', 'massive:search:status');
+        $command = $this->getCommand('phpcr', 'massive:search:init');
         $command->execute([]);
 
         $this->assertEquals(0, $command->getStatusCode());

--- a/Tests/Unit/DependencyInjection/MassiveSearchExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/MassiveSearchExtensionTest.php
@@ -12,7 +12,10 @@
 namespace Massive\Bundle\SearchBundle\Unit\DependencyInjection;
 
 use Massive\Bundle\SearchBundle\DependencyInjection\MassiveSearchExtension;
+use Massive\Bundle\SearchBundle\MassiveSearchBundle;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Filesystem\Filesystem;
 
 class MassiveSearchExtensionTest extends AbstractExtensionTestCase
 {
@@ -23,12 +26,13 @@ class MassiveSearchExtensionTest extends AbstractExtensionTestCase
         $this->container->setParameter('kernel.root_dir', '/some/path');
         $this->container->setParameter('kernel.cache_dir', __DIR__ . '/../../Resources/app/cache');
         $this->container->setParameter('kernel.debug', false);
-        $this->container->register('event_dispatcher', 'Symfony\Component\EventDispatcher\EventDispatcher');
+        $this->container->register('event_dispatcher', EventDispatcher::class);
+        $this->container->register('filesystem', Filesystem::class);
     }
 
     protected function getContainerExtensions()
     {
-        $this->container->setParameter('kernel.bundles', ['Massive\Bundle\SearchBundle\MassiveSearchBundle']);
+        $this->container->setParameter('kernel.bundles', [MassiveSearchBundle::class]);
         $this->container->setParameter('kernel.root_dir', __DIR__ . '/../../Resources/app');
 
         return [

--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,11 @@
         "behat/behat": "~3.0.0",
         "behat/web-api-extension": "~1.0@dev",
         "behat/symfony2-extension": "~2.0@dev",
-        "phpbench/phpbench": "~1.0@dev",
+        "phpbench/phpbench": "~0.10.0",
         "phpbench/tabular": "@dev"
     },
     "suggest": {
+        "sensio/distribution-bundle": "Required if the SearchScriptHandler is used",
         "zendframework/zendsearch": "To use the PHP based Zend Search library (based on Lucene)",
         "zendframework/zend-stdlib": "(dependency of zendsearch)",
         "elasticsearch/elasticsearch": "To use Elasticsearch"


### PR DESCRIPTION
This PR adds a new command `massive:search:init` and a composer script handler calling this command. This is useful to make the installation process easier, because the creation of this folder is already done by composer and does not have to be done manually. Another advantage is that always the correct folder based on the configuration is created.