### PR TITLE
Adds mapping for the image field

### DIFF
--- a/Search/Metadata/Driver/XmlDriver.php
+++ b/Search/Metadata/Driver/XmlDriver.php
@@ -118,6 +118,7 @@ class XmlDriver extends AbstractFileDriver implements DriverInterface
             $indexMetadata->setTitleField($mapping['title']);
             $indexMetadata->setUrlField($mapping['url']);
             $indexMetadata->setDescriptionField($mapping['description']);
+            $indexMetadata->setImageUrlField($mapping['image']);
 
             foreach ($mapping['fields'] as $fieldName => $fieldData) {
                 $indexMetadata->addFieldMapping($fieldName, $fieldData);
@@ -150,6 +151,9 @@ class XmlDriver extends AbstractFileDriver implements DriverInterface
 
         $descriptionField = $this->getMapping($mapping, 'description');
         $indexMapping['description'] = $descriptionField;
+
+        $imageField = $this->getMapping($mapping, 'image');
+        $indexMapping['image'] = $imageField;
 
         return $indexMapping;
     }

--- a/Tests/Features/general.feature
+++ b/Tests/Features/general.feature
@@ -114,7 +114,7 @@ Feature: Search Manager
                 "description": "Hello",
                 "class": "Massive\\Bundle\\SearchBundle\\Tests\\Resources\\TestBundle\\Entity\\Car",
                 "url": "foobar",
-                "image_url": "",
+                "image_url": "foo.jpg",
                 "locale": "fr"
             }
         ]


### PR DESCRIPTION
Here comes the pull request, which adds the mapping for the image-field missing in the XmlDriver. 

As requested, it fixes #84.
