### PR TITLE
Fixed memory usage for reindex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG
 =========
 
+* dev-master
+    * HOTFIX  #92 Fixed memory usage for reindex
+
 * 0.13.1 (2016-05-09)
     * BUGFIX  #90 Fixed elastic search params array
 

--- a/Search/Reindex/ReindexProviderInterface.php
+++ b/Search/Reindex/ReindexProviderInterface.php
@@ -30,6 +30,13 @@ interface ReindexProviderInterface
     public function provide($classFqn, $offset, $maxResults);
 
     /**
+     * Cleanup memory for given $classFqn.
+     *
+     * @param string $classFqn
+     */
+    public function cleanUp($classFqn);
+
+    /**
      * Return the total number of objects that need to be reindexed.
      *
      * @param string $classFqn

--- a/Tests/Unit/Command/ReindexCommandTest.php
+++ b/Tests/Unit/Command/ReindexCommandTest.php
@@ -121,10 +121,11 @@ class ReindexCommandTest extends \PHPUnit_Framework_TestCase
         $this->provider1->provide('stdClass', 0, 50)->willReturn($batch1);
         $this->provider1->provide('stdClass', 50, 50)->willReturn($batch2);
         $this->provider1->provide('stdClass', 100, 50)->willReturn([]);
+        $this->provider1->cleanUp('stdClass')->shouldBeCalledTimes(3);
 
         $this->resumeManager->getCheckpoint($providerName, $classFqn)->willReturn(null);
-        $this->resumeManager->setCheckpoint($providerName, $classFqn, 0)->shouldBeCalled();
         $this->resumeManager->setCheckpoint($providerName, $classFqn, 50)->shouldBeCalled();
+        $this->resumeManager->setCheckpoint($providerName, $classFqn, 100)->shouldBeCalled();
         $this->resumeManager->removeCheckpoints($providerName)->shouldBeCalled();
 
         $tester = $this->execute('prod', []);
@@ -153,6 +154,7 @@ class ReindexCommandTest extends \PHPUnit_Framework_TestCase
         $this->localizedProvider1->getCount('stdClass')->willReturn($count);
         $this->localizedProvider1->provide('stdClass', 0, 50)->willReturn($batch);
         $this->localizedProvider1->provide('stdClass', 50, 50)->willReturn([]);
+        $this->localizedProvider1->cleanUp('stdClass')->shouldBeCalledTimes(2);
 
         foreach ($batch as $object) {
             $this->localizedProvider1->getLocalesForObject($object)->willReturn(['de', 'fr']);
@@ -165,7 +167,8 @@ class ReindexCommandTest extends \PHPUnit_Framework_TestCase
         }
 
         $this->resumeManager->getCheckpoint($providerName, $classFqn)->willReturn(null);
-        $this->resumeManager->setCheckpoint($providerName, $classFqn, 0)->shouldBeCalled();
+        $this->resumeManager->setCheckpoint($providerName, $classFqn, 50)->shouldBeCalled();
+        $this->resumeManager->setCheckpoint($providerName, $classFqn, 100)->shouldBeCalled();
         $this->resumeManager->removeCheckpoints($providerName)->shouldBeCalled();
 
         $tester = $this->execute('prod', []);
@@ -193,9 +196,11 @@ class ReindexCommandTest extends \PHPUnit_Framework_TestCase
         $this->provider1->getCount('stdClass')->willReturn($count);
         $this->provider1->provide('stdClass', 23, 50)->willReturn([new \stdClass()]);
         $this->provider1->provide('stdClass', 73, 50)->willReturn([]);
+        $this->provider1->cleanUp('stdClass')->shouldBeCalledTimes(2);
 
         $this->resumeManager->getCheckpoint($providerName, $classFqn)->willReturn(23);
-        $this->resumeManager->setCheckpoint($providerName, $classFqn, 23)->shouldBeCalled();
+        $this->resumeManager->setCheckpoint($providerName, $classFqn, 73)->shouldBeCalled();
+        $this->resumeManager->setCheckpoint($providerName, $classFqn, 100)->shouldBeCalled();
         $this->resumeManager->removeCheckpoints($providerName)->shouldBeCalled();
 
         $this->execute('prod', []);


### PR DESCRIPTION
This PR introduces the cleanup after each "batch" which was reindexed. This reduces the memory usage a lot.