### PR TITLE
Fixed prefix is-variant when index has wrong prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG
 =========
 
 * dev-master
+    * HOTFIX  #95 Fixed prefix is-variant when index has wrong prefix 
     * HOTFIX  #92 Fixed memory usage for reindex
 
 * 0.13.1 (2016-05-09)

--- a/Search/Decorator/PrefixDecorator.php
+++ b/Search/Decorator/PrefixDecorator.php
@@ -60,7 +60,7 @@ class PrefixDecorator implements IndexNameDecoratorInterface
      */
     public function isVariant($indexName, $decoratedIndexName, array $options = [])
     {
-        if ($indexName === $decoratedIndexName && $this->prefix) {
+        if (($indexName === $decoratedIndexName && $this->prefix) || 0 !== strpos($decoratedIndexName, $this->prefix)) {
             // if both names are the same, and a prefix is set the name was not decorated by this decorator
             return false;
         }

--- a/Tests/Unit/Search/Decorator/PrefixDecoratorTest.php
+++ b/Tests/Unit/Search/Decorator/PrefixDecoratorTest.php
@@ -78,7 +78,7 @@ class PrefixDecoratorTest extends \PHPUnit_Framework_TestCase
     {
         $this->otherDecorator->isVariant(Argument::any(), Argument::any(), Argument::any())->willReturn(true);
         $this->otherDecorator->undecorate('my_index')->willReturn('my_index');
-        $this->assertFalse($this->prefixDecorator->isVariant('prefixed_my_index', 'my_index'));
+        $this->assertFalse($this->prefixDecorator->isVariant('prefixed_my_index', 'prefixed_my_index'));
     }
 
     public function testIsVariantWithoutPrefix()


### PR DESCRIPTION
This PR fixes the variant-detection for `PrefixDecorator`.