### PR TITLE
Implemented sorting for zend-lucene-adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ CHANGELOG
 =========
 
 * dev-develop
+    * FEATURE     #97 Implemented sorting for zend-lucene-adapter
+    * FEATURE     #79 Consider limit + offset for searching
     * ENHANCEMENT #96 Updated elasticsearch dependency
     * BUGFIX      #93 Fixed composer-events
     * BUGFIX      #87 Added missing support for image field in XML document.

--- a/Search/Adapter/Zend/MatchAllQuery.php
+++ b/Search/Adapter/Zend/MatchAllQuery.php
@@ -1,0 +1,366 @@
+<?php
+
+/*
+ * This file is part of the MassiveSearchBundle
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Massive\Bundle\SearchBundle\Search\Adapter\Zend;
+
+use Zend\Stdlib\ErrorHandler;
+use ZendSearch\Lucene;
+use ZendSearch\Lucene\Analysis\Analyzer\Analyzer;
+use ZendSearch\Lucene\Exception\OutOfBoundsException;
+use ZendSearch\Lucene\Exception\RuntimeException;
+use ZendSearch\Lucene\Exception\UnsupportedMethodCallException;
+use ZendSearch\Lucene\Index\Term;
+use ZendSearch\Lucene\Search\Highlighter\HighlighterInterface as Highlighter;
+use ZendSearch\Lucene\Search\Query\AbstractQuery;
+use ZendSearch\Lucene\Search\Query\EmptyResult;
+use ZendSearch\Lucene\Search\Query\MultiTerm;
+
+/**
+ * This Query was inspired by ZendSearch\Lucene\Search\QueryWildcard.
+ *
+ * Changes:
+ *  - $_minPrefixLength was set to zero
+ *  - term is fix "*"
+ */
+class MatchAllQuery extends AbstractQuery
+{
+    /**
+     * Search pattern.
+     *
+     * Field has to be fully specified or has to be null
+     * Text may contain '*' or '?' symbols
+     *
+     * @var \ZendSearch\Lucene\Index\Term
+     */
+    private $_pattern;
+
+    /**
+     * Matched terms.
+     *
+     * Matched terms list.
+     * It's filled during the search (rewrite operation) and may be used for search result
+     * post-processing
+     *
+     * Array of Zend_Search_Lucene_Index_Term objects
+     *
+     * @var array
+     */
+    private $_matches = null;
+
+    /**
+     * Minimum term prefix length (number of minimum non-wildcard characters).
+     *
+     * @var int
+     */
+    private static $_minPrefixLength = 0;
+
+    /**
+     * Zend_Search_Lucene_Search_Query_Wildcard constructor.
+     */
+    public function __construct()
+    {
+        $this->_pattern = new Term('*');
+    }
+
+    /**
+     * Get minimum prefix length.
+     *
+     * @return int
+     */
+    public static function getMinPrefixLength()
+    {
+        return self::$_minPrefixLength;
+    }
+
+    /**
+     * Set minimum prefix length.
+     *
+     * @param int $minPrefixLength
+     */
+    public static function setMinPrefixLength($minPrefixLength)
+    {
+        self::$_minPrefixLength = $minPrefixLength;
+    }
+
+    /**
+     * Get terms prefix.
+     *
+     * @param string $word
+     *
+     * @return string
+     */
+    private static function _getPrefix($word)
+    {
+        $questionMarkPosition = strpos($word, '?');
+        $astrericPosition = strpos($word, '*');
+
+        if ($questionMarkPosition !== false) {
+            if ($astrericPosition !== false) {
+                return substr($word, 0, min($questionMarkPosition, $astrericPosition));
+            }
+
+            return substr($word, 0, $questionMarkPosition);
+        } elseif ($astrericPosition !== false) {
+            return substr($word, 0, $astrericPosition);
+        }
+
+        return $word;
+    }
+
+    /**
+     * Re-write query into primitive queries in the context of specified index.
+     *
+     * @param \ZendSearch\Lucene\SearchIndexInterface $index
+     *
+     * @throws \ZendSearch\Lucene\Exception\RuntimeException
+     * @throws \ZendSearch\Lucene\Exception\OutOfBoundsException
+     *
+     * @return \ZendSearch\Lucene\Search\Query\AbstractQuery
+     */
+    public function rewrite(Lucene\SearchIndexInterface $index)
+    {
+        $this->_matches = [];
+
+        if ($this->_pattern->field === null) {
+            // Search through all fields
+            $fields = $index->getFieldNames(true /* indexed fields list */);
+        } else {
+            $fields = [$this->_pattern->field];
+        }
+
+        $prefix = self::_getPrefix($this->_pattern->text);
+        $prefixLength = strlen($prefix);
+        $matchExpression = '/^' . str_replace(['\\?', '\\*'], ['.', '.*'], preg_quote($this->_pattern->text, '/')) . '$/';
+
+        if ($prefixLength < self::$_minPrefixLength) {
+            throw new RuntimeException(
+                'At least ' . self::$_minPrefixLength . ' non-wildcard characters are required at the beginning of pattern.'
+            );
+        }
+
+        /**
+         * @todo check for PCRE unicode support may be performed through Zend_Environment in some future
+         */
+        ErrorHandler::start(E_WARNING);
+        $result = preg_match('/\pL/u', 'a');
+        ErrorHandler::stop();
+        if ($result == 1) {
+            // PCRE unicode support is turned on
+            // add Unicode modifier to the match expression
+            $matchExpression .= 'u';
+        }
+
+        $maxTerms = Lucene\Lucene::getTermsPerQueryLimit();
+        foreach ($fields as $field) {
+            $index->resetTermsStream();
+
+            if ($prefix != '') {
+                $index->skipTo(new Term($prefix, $field));
+
+                while ($index->currentTerm() !== null          &&
+                    $index->currentTerm()->field == $field  &&
+                    substr($index->currentTerm()->text, 0, $prefixLength) == $prefix) {
+                    if (preg_match($matchExpression, $index->currentTerm()->text) === 1) {
+                        $this->_matches[] = $index->currentTerm();
+
+                        if ($maxTerms != 0  &&  count($this->_matches) > $maxTerms) {
+                            throw new OutOfBoundsException('Terms per query limit is reached.');
+                        }
+                    }
+
+                    $index->nextTerm();
+                }
+            } else {
+                $index->skipTo(new Term('', $field));
+
+                while ($index->currentTerm() !== null  &&  $index->currentTerm()->field == $field) {
+                    if (preg_match($matchExpression, $index->currentTerm()->text) === 1) {
+                        $this->_matches[] = $index->currentTerm();
+
+                        if ($maxTerms != 0  &&  count($this->_matches) > $maxTerms) {
+                            throw new OutOfBoundsException('Terms per query limit is reached.');
+                        }
+                    }
+
+                    $index->nextTerm();
+                }
+            }
+
+            $index->closeTermsStream();
+        }
+
+        if (count($this->_matches) == 0) {
+            return new EmptyResult();
+        } elseif (count($this->_matches) == 1) {
+            return new Term(reset($this->_matches));
+        } else {
+            $rewrittenQuery = new MultiTerm();
+
+            foreach ($this->_matches as $matchedTerm) {
+                $rewrittenQuery->addTerm($matchedTerm);
+            }
+
+            return $rewrittenQuery;
+        }
+    }
+
+    /**
+     * Optimize query in the context of specified index.
+     *
+     * @param \ZendSearch\Lucene\SearchIndexInterface $index
+     *
+     * @throws \ZendSearch\Lucene\Exception\UnsupportedMethodCallException
+     *
+     * @return \ZendSearch\Lucene\Search\Query\AbstractQuery
+     */
+    public function optimize(Lucene\SearchIndexInterface $index)
+    {
+        throw new UnsupportedMethodCallException('Wildcard query should not be directly used for search. Use $query->rewrite($index)');
+    }
+
+    /**
+     * Returns query pattern.
+     *
+     * @return \ZendSearch\Lucene\Index\Term
+     */
+    public function getPattern()
+    {
+        return $this->_pattern;
+    }
+
+    /**
+     * Return query terms.
+     *
+     * @throws \ZendSearch\Lucene\Exception\RuntimeException
+     *
+     * @return array
+     */
+    public function getQueryTerms()
+    {
+        if ($this->_matches === null) {
+            throw new RuntimeException('Search has to be performed first to get matched terms');
+        }
+
+        return $this->_matches;
+    }
+
+    /**
+     * Constructs an appropriate Weight implementation for this query.
+     *
+     * @param \ZendSearch\Lucene\SearchIndexInterface $reader
+     *
+     * @throws \ZendSearch\Lucene\Exception\UnsupportedMethodCallException
+     */
+    public function createWeight(Lucene\SearchIndexInterface $reader)
+    {
+        throw new UnsupportedMethodCallException('Wildcard query should not be directly used for search. Use $query->rewrite($index)');
+    }
+
+    /**
+     * Execute query in context of index reader
+     * It also initializes necessary internal structures.
+     *
+     * @param \ZendSearch\Lucene\SearchIndexInterface $reader
+     * @param \ZendSearch\Lucene\Index\DocsFilter|null $docsFilter
+     *
+     * @throws \ZendSearch\Lucene\Exception\UnsupportedMethodCallException
+     */
+    public function execute(Lucene\SearchIndexInterface $reader, $docsFilter = null)
+    {
+        throw new UnsupportedMethodCallException('Wildcard query should not be directly used for search. Use $query->rewrite($index)');
+    }
+
+    /**
+     * Get document ids likely matching the query.
+     *
+     * It's an array with document ids as keys (performance considerations)
+     *
+     * @throws \ZendSearch\Lucene\Exception\UnsupportedMethodCallException
+     *
+     * @return array
+     */
+    public function matchedDocs()
+    {
+        throw new UnsupportedMethodCallException(
+            'Wildcard query should not be directly used for search. Use $query->rewrite($index)'
+        );
+    }
+
+    /**
+     * Score specified document.
+     *
+     * @param int $docId
+     * @param \ZendSearch\Lucene\SearchIndexInterface $reader
+     *
+     * @throws \ZendSearch\Lucene\Exception\UnsupportedMethodCallException
+     *
+     * @return float
+     */
+    public function score($docId, Lucene\SearchIndexInterface $reader)
+    {
+        throw new UnsupportedMethodCallException(
+            'Wildcard query should not be directly used for search. Use $query->rewrite($index)'
+        );
+    }
+
+    /**
+     * Query specific matches highlighting.
+     *
+     * @param Highlighter $highlighter  Highlighter object (also contains doc for highlighting)
+     */
+    protected function _highlightMatches(Highlighter $highlighter)
+    {
+        $words = [];
+
+        $matchExpression = '/^' . str_replace(['\\?', '\\*'], ['.', '.*'], preg_quote($this->_pattern->text, '/')) . '$/';
+        ErrorHandler::start(E_WARNING);
+        $result = preg_match('/\pL/u', 'a');
+        ErrorHandler::stop();
+        if ($result == 1) {
+            // PCRE unicode support is turned on
+            // add Unicode modifier to the match expression
+            $matchExpression .= 'u';
+        }
+
+        $docBody = $highlighter->getDocument()->getFieldUtf8Value('body');
+        $tokens = Analyzer::getDefault()->tokenize($docBody, 'UTF-8');
+        foreach ($tokens as $token) {
+            if (preg_match($matchExpression, $token->getTermText()) === 1) {
+                $words[] = $token->getTermText();
+            }
+        }
+
+        $highlighter->highlight($words);
+    }
+
+    /**
+     * Print a query.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        // It's used only for query visualisation, so we don't care about characters escaping
+        if ($this->_pattern->field !== null) {
+            $query = $this->_pattern->field . ':';
+        } else {
+            $query = '';
+        }
+
+        $query .= $this->_pattern->text;
+
+        if ($this->getBoost() != 1) {
+            $query = $query . '^' . round($this->getBoost(), 4);
+        }
+
+        return $query;
+    }
+}

--- a/Search/Adapter/ZendLuceneAdapter.php
+++ b/Search/Adapter/ZendLuceneAdapter.php
@@ -16,9 +16,9 @@ use Massive\Bundle\SearchBundle\Search\AdapterInterface;
 use Massive\Bundle\SearchBundle\Search\Document;
 use Massive\Bundle\SearchBundle\Search\Factory;
 use Massive\Bundle\SearchBundle\Search\Field;
-use Massive\Bundle\SearchBundle\Search\QueryHit;
 use Massive\Bundle\SearchBundle\Search\SearchQuery;
 use Massive\Bundle\SearchBundle\Search\SearchResult;
+use Massive\Bundle\SearchBundle\Util\SortUtils;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use ZendSearch\Lucene;
@@ -251,17 +251,22 @@ class ZendLuceneAdapter implements AdapterInterface
             $hits[] = $hit;
         }
 
-        // The MultiSearcher does not support sorting, so we do it here.
-        usort(
-            $hits,
-            function (QueryHit $documentA, QueryHit $documentB) {
-                if ($documentA->getScore() < $documentB->getScore()) {
-                    return true;
-                }
+        // default sortings
+        $sortings = ['getScore'];
+        $direction = 'desc';
 
-                return false;
-            }
-        );
+        $querySortings = $searchQuery->getSortings();
+        if (0 < count($querySortings)) {
+            $direction = reset($querySortings);
+            $sortings = array_map(
+                function ($sorting) {
+                    return sprintf('getDocument.%s', $sorting);
+                },
+                array_keys($querySortings)
+            );
+        }
+
+        $hits = SortUtils::multisort($hits, $sortings, $direction);
 
         return new SearchResult($hits, count($luceneHits));
     }

--- a/Search/Adapter/ZendLuceneAdapter.php
+++ b/Search/Adapter/ZendLuceneAdapter.php
@@ -12,6 +12,7 @@
 namespace Massive\Bundle\SearchBundle\Search\Adapter;
 
 use Massive\Bundle\SearchBundle\Search\Adapter\Zend\Index;
+use Massive\Bundle\SearchBundle\Search\Adapter\Zend\MatchAllQuery;
 use Massive\Bundle\SearchBundle\Search\AdapterInterface;
 use Massive\Bundle\SearchBundle\Search\Document;
 use Massive\Bundle\SearchBundle\Search\Factory;
@@ -198,7 +199,11 @@ class ZendLuceneAdapter implements AdapterInterface
             $searcher->addIndex($this->getIndex($indexPath, false));
         }
 
-        $query = Lucene\Search\QueryParser::parse($queryString);
+        if (0 === strlen($queryString)) {
+            $query = new MatchAllQuery();
+        } else {
+            $query = Lucene\Search\QueryParser::parse($queryString);
+        }
 
         try {
             $luceneHits = $searcher->find($query);

--- a/Search/Document.php
+++ b/Search/Document.php
@@ -238,6 +238,18 @@ class Document implements \JsonSerializable
     }
 
     /**
+     * Returns the named field.
+     *
+     * @param string $name
+     *
+     * @return Field
+     */
+    public function __get($name)
+    {
+        return $this->getField($name);
+    }
+
+    /**
      * Return true if the field exists.
      *
      * @return bool

--- a/Search/SearchManager.php
+++ b/Search/SearchManager.php
@@ -115,10 +115,10 @@ class SearchManager implements SearchManagerInterface
 
         foreach ($metadata->getIndexMetadatas() as $indexMetadata) {
             $indexName = $this->fieldEvaluator->getValue($object, $indexMetadata->getIndexName());
-            $this->markIndexToFlush($indexName);
             $indexNames = $this->getDecoratedIndexNames($indexName);
 
             foreach ($indexNames as $indexName) {
+                $this->markIndexToFlush($indexName);
                 $document = $this->converter->objectToDocument($indexMetadata, $object);
                 $this->adapter->deindex($document, $indexName);
             }
@@ -216,9 +216,9 @@ class SearchManager implements SearchManagerInterface
      */
     public function purge($indexName)
     {
-        $this->markIndexToFlush($indexName);
         $indexes = $this->getDecoratedIndexNames($indexName);
         foreach ($indexes as $indexName) {
+            $this->markIndexToFlush($indexName);
             $this->adapter->purge($indexName);
         }
     }

--- a/Tests/Features/general.feature
+++ b/Tests/Features/general.feature
@@ -134,3 +134,14 @@ Feature: Search Manager
     Scenario: Return the status
         When I get the status
         Then the result should be an array
+
+    Scenario: Match all
+        Given the following "Car" objects have been indexed
+        """
+        [
+            { "id": 123, "url": "/url/to", "title": "My car", "body": "Hello", "image": "foo.jpg"},
+            { "id": 321, "url": "/url/to", "title": "My car", "body": "Hello", "image": "foo.jpg"}
+        ]
+        """
+        When I search for "Car"
+        Then there should be 2 results

--- a/Tests/Features/sorting.feature
+++ b/Tests/Features/sorting.feature
@@ -1,4 +1,4 @@
-@elastic
+@zend_lucene @elastic
 Feature: Search Manager
   In order to manage the search indexing of objects
   As a developer

--- a/Tests/Unit/Util/SortUtilsTest.php
+++ b/Tests/Unit/Util/SortUtilsTest.php
@@ -1,0 +1,182 @@
+<?php
+
+/*
+ * This file is part of the MassiveSearchBundle
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Massive\Bundle\SearchBundle\Unit\Util;
+
+use Massive\Bundle\SearchBundle\Util\SortUtils;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+
+class SortUtilsTest extends \PHPUnit_Framework_TestCase
+{
+    public function provideSortObjects()
+    {
+        return [
+            // ascending
+            [
+                [
+                    new FoobarTestClass('ccc', 'aaa'),
+                    new FoobarTestClass('bbb', 'aaa'),
+                    new FoobarTestClass('aaa', 'aaa'),
+                ],
+                'getField1',
+                'asc',
+                'field1', ['aaa', 'bbb', 'ccc'],
+            ],
+
+            // descending
+            [
+                [
+                    new FoobarTestClass('ccc', 'aaa'),
+                    new FoobarTestClass('bbb', 'aaa'),
+                    new FoobarTestClass('aaa', 'aaa'),
+                ],
+                'getField1',
+                'desc',
+                'field1', ['ccc', 'bbb', 'aaa'],
+            ],
+
+            // sort on a different method
+            [
+                [
+                    new FoobarTestClass('ccc', 'aaa'),
+                    new FoobarTestClass('bbb', 'bbb'),
+                    new FoobarTestClass('aaa', 'ccc'),
+                ],
+                'getField2',
+                'desc',
+                'field1', ['aaa', 'bbb', 'ccc'],
+            ],
+
+            // sort by two methods
+            [
+                [
+                    new FoobarTestClass('ccc', 'aaa'),
+                    new FoobarTestClass('bbb', 'aaa'),
+                    new FoobarTestClass('aaa', 'aaa'),
+                ],
+                ['getField2', 'getField1'],
+                'asc',
+                'field1', ['aaa', 'bbb', 'ccc'],
+            ],
+
+            // check sorting numerical strings
+            [
+                [
+                    new FoobarTestClass('15', 'aaa'),
+                    new FoobarTestClass('100', 'bbb'),
+                    new FoobarTestClass('200', 'ccc'),
+                ],
+                'getField1',
+                'asc',
+                'field1', ['15', '100', '200'],
+            ],
+
+            // check array
+            [
+                [
+                    ['foo' => 'zzz', 'bar' => 'aaa'],
+                    ['foo' => 'xxx', 'bar' => 'aaa'],
+                    ['foo' => 'yyy', 'bar' => 'aaa'],
+                ],
+                '[foo]',
+                'asc',
+                '[foo]', ['xxx', 'yyy', 'zzz'],
+            ],
+
+            // multi dimensional array
+            [
+                [
+                    ['foo' => '1', 'baz' => ['bar' => 'bbb']],
+                    ['foo' => '2', 'baz' => ['bar' => 'aaa']],
+                    ['foo' => '3', 'baz' => ['bar' => 'ccc']],
+                ],
+                '[baz][bar]',
+                'asc',
+                '[foo]', ['2', '1', '3'],
+            ],
+
+            // multi dimensional array missing key
+            [
+                [
+                    ['foo' => '1', 'baz' => ['bar' => 'bbb']],
+                    ['foo' => '2', 'baz' => ['sad' => 'aaa']],
+                    ['foo' => '3', 'baz' => ['bad' => 'ccc']],
+                ],
+                '[baz][bar]',
+                'asc',
+                '[foo]', ['3', '2', '1'],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideSortObjects
+     */
+    public function testSortObjects($data, $methodName, $direction, $checkField, $expectedOrder)
+    {
+        $accessor = PropertyAccess::createPropertyAccessor();
+
+        $res = SortUtils::multisort($data, $methodName, $direction);
+
+        foreach ($expectedOrder as $expected) {
+            $object = array_shift($res);
+            $this->assertEquals($expected, $accessor->getValue($object, $checkField));
+        }
+    }
+
+    public function testSortArrayObject()
+    {
+        $collection = new \ArrayObject([
+            new FoobarTestClass('value2', 'value2'),
+            new FoobarTestClass('value1', 'value2'),
+        ]);
+
+        $res = SortUtils::multisort($collection, 'getField1');
+
+        $this->assertEquals('value1', $res[0]->field1);
+        $this->assertEquals('value2', $res[0]->field2);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException
+     */
+    public function testSortMissingField()
+    {
+        $collection = new \ArrayObject([
+            (object) ['value2', 'value2'],
+            (object) ['value1', 'value2'],
+        ]);
+
+        SortUtils::multisort($collection, 'somefink');
+    }
+}
+
+class FoobarTestClass
+{
+    public $field1;
+    public $field2;
+
+    public function __construct($value1, $value2)
+    {
+        $this->field1 = $value1;
+        $this->field2 = $value2;
+    }
+
+    public function getField1()
+    {
+        return $this->field1;
+    }
+
+    public function getField2()
+    {
+        return $this->field2;
+    }
+}

--- a/Util/SortUtils.php
+++ b/Util/SortUtils.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the MassiveSearchBundle
+ *
+ * (c) MASSIVE ART WebServices GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Massive\Bundle\SearchBundle\Util;
+
+use Symfony\Component\PropertyAccess\PropertyAccess;
+
+/**
+ * Sorting utilities.
+ */
+final class SortUtils
+{
+    /**
+     * Cannot instantiate this class.
+     */
+    final private function __construct()
+    {
+    }
+
+    /**
+     * Sort the given array of arrays/objects using paths.
+     *
+     * e.g.
+     *
+     *      $data = array(
+     *          array('foobar' => 'b'),
+     *          array('foobar' => 'a'),
+     *      );
+     *
+     *      SortUtils::multisort($data, '[foobar]', 'asc');
+     *
+     *      echo $data[0]; // "a"
+     *
+     * You can also use method names:
+     *
+     *      SortUtils::multisort($data, 'getFoobar', 'asc');
+     *
+     * Or sort on multidimensional arrays:
+     *
+     *      SortUtils::multisort($data, 'foobar.bar.getFoobar', 'asc');
+     *
+     * And you can sort on multiple paths:
+     *
+     *      SortUtils::multisort($data, array('foo', 'bar'), 'asc');
+     *
+     * The path is any path accepted by the property access component:
+     *
+     * @link http://symfony.com/doc/current/components/property_access/introduction.html
+     *
+     * @param array $values
+     * @param string|array $path Path or paths on which to sort on
+     * @param string $direction Direction to sort in (either ASC or DESC)
+     *
+     * @return array
+     */
+    public static function multisort($values, $paths, $direction = 'ASC')
+    {
+        $accessor = PropertyAccess::createPropertyAccessor();
+
+        $values = (array) $values;
+        $paths = (array) $paths;
+
+        usort(
+            $values,
+            function ($a, $b) use ($accessor, $paths) {
+                foreach ($paths as $i => $path) {
+                    $aOrder = $accessor->getValue($a, $path);
+                    $bOrder = $accessor->getValue($b, $path);
+
+                    if (is_string($aOrder)) {
+                        $aOrder = strtolower($aOrder);
+                        $bOrder = strtolower($bOrder);
+                    }
+
+                    if ($aOrder == $bOrder) {
+                        if (count($paths) == ($i + 1)) {
+                            return 0;
+                        } else {
+                            continue;
+                        }
+                    }
+
+                    return ($aOrder < $bOrder) ? -1 : 1;
+                }
+            }
+        );
+
+        if (strtoupper($direction) == 'DESC') {
+            $values = array_reverse($values);
+        }
+
+        return $values;
+    }
+}


### PR DESCRIPTION
This feature introduces simple sorting for zend-lucene adapter.

Additionally this PR enables empty searches for elastic-search and zend-lucene.
