### PR TITLE
Added __id field for compatability reasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 * dev-develop
-    * BUGFIX      #104 Added __id field for compatability reasons
+    * BUGFIX      #104 Added `__id` field for compatability reasons
     * ENHANCEMENT #103 Added elasticsearch version config parameter
 
 * 0.15.0 (2016-08-08)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG
 =========
 
 * dev-develop
+    * BUGFIX      #104 Added __id field for compatability reasons
     * ENHANCEMENT #103 Added elasticsearch version config parameter
 
 * 0.15.0 (2016-08-08)

--- a/Search/Adapter/ElasticSearchAdapter.php
+++ b/Search/Adapter/ElasticSearchAdapter.php
@@ -103,6 +103,7 @@ class ElasticSearchAdapter implements AdapterInterface
             }
         }
 
+        $fields[self::ID_FIELDNAME] = $document->getId();
         $fields[self::INDEX_FIELDNAME] = $document->getIndex();
         $fields[self::URL_FIELDNAME] = $document->getUrl();
         $fields[self::TITLE_FIELDNAME] = $document->getTitle();


### PR DESCRIPTION
This PR introduces a __id field for compatibility reasons between zend and elastic-search.