### PR TITLE
Added encode and decode field-name to elasticsearch adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG
 =========
 
+* dev-master
+    * HOTFIX      #107 Added encode and decode field-name to elasticsearch adapter
+
 * 0.16.0 (2016-10-06)
     * BUGFIX      #104 Added `__id` field for compatability reasons
     * ENHANCEMENT #103 Added elasticsearch version config parameter

--- a/Search/Adapter/ElasticSearchAdapter.php
+++ b/Search/Adapter/ElasticSearchAdapter.php
@@ -87,7 +87,7 @@ class ElasticSearchAdapter implements AdapterInterface
             switch ($type) {
                 case Field::TYPE_STRING:
                 case Field::TYPE_ARRAY:
-                    $fields[$massiveField->getName()] = $value;
+                    $fields[$this->encodeFieldName($massiveField->getName())] = $value;
                     break;
                 case Field::TYPE_NULL:
                     // ignore it
@@ -213,7 +213,7 @@ class ElasticSearchAdapter implements AdapterInterface
             $hit->setId($document->getId());
 
             foreach ($elasticSource as $fieldName => $fieldValue) {
-                $document->addField($this->factory->createField($fieldName, $fieldValue));
+                $document->addField($this->factory->createField($this->decodeFieldName($fieldName), $fieldValue));
             }
             $hits[] = $hit;
         }
@@ -322,5 +322,29 @@ class ElasticSearchAdapter implements AdapterInterface
         }
 
         return $this->client->indices()->status(['index' => '_all']);
+    }
+
+    /**
+     * Returns encoded field-name.
+     *
+     * @param string $fieldName
+     *
+     * @return string
+     */
+    private function encodeFieldName($fieldName)
+    {
+        return str_replace('.', '#', $fieldName);
+    }
+
+    /**
+     * Returns decoded field-name.
+     *
+     * @param string $fieldName
+     *
+     * @return string
+     */
+    private function decodeFieldName($fieldName)
+    {
+        return str_replace('#', '.', $fieldName);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=4.8",
+        "phpunit/phpunit": "^4.8 || ^5.7",
 
         "zendframework/zend-stdlib": "2.3.1 as 2.0.0rc5",
         "zendframework/zendsearch": "2.*@dev",
         "elasticsearch/elasticsearch": "^2.1",
-        "symfony-cmf/testing": "dev-master",
+        "symfony-cmf/testing": "^1.3",
         "symfony/symfony": "~2.7||~3.0",
         "matthiasnoback/symfony-dependency-injection-test": "0.7.*",
         "doctrine/doctrine-bundle": "~1.4",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,6 +22,7 @@
     </filter>
 
     <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
         <server name="KERNEL_DIR" value="Tests/Resources/app" />
     </php>
 


### PR DESCRIPTION
Fixes https://github.com/sulu/sulu/issues/3274

The dot is a reserved character in elasticsearch (besides `:`, `+` and `-`) - so we have decided to replace it with something else (on index and search time).