### PR TITLE
Highlighting of search hits in searched fields

### DIFF
--- a/Search/Adapter/ElasticSearchAdapter.php
+++ b/Search/Adapter/ElasticSearchAdapter.php
@@ -167,8 +167,8 @@ class ElasticSearchAdapter implements AdapterInterface
         }
         if (!empty($searchQuery->getHighlightFields())) {
             $params['body']['highlight'] = [
-                "require_field_match" => false,
-                "fields" => [],
+                'require_field_match' => false,
+                'fields' => [],
             ];
 
             foreach ($searchQuery->getHighlightFields() as $field) {

--- a/Search/Adapter/ElasticSearchAdapter.php
+++ b/Search/Adapter/ElasticSearchAdapter.php
@@ -183,8 +183,6 @@ class ElasticSearchAdapter implements AdapterInterface
             ];
         }
 
-        error_log(json_encode($params));
-
         $res = $this->client->search($params);
         $elasticHits = $res['hits']['hits'];
 

--- a/Search/Adapter/ElasticSearchAdapter.php
+++ b/Search/Adapter/ElasticSearchAdapter.php
@@ -168,7 +168,7 @@ class ElasticSearchAdapter implements AdapterInterface
         if (!empty($searchQuery->getHighlightFields())) {
             $params['body']['highlight'] = [
                 "require_field_match" => false,
-                "fields" => []
+                "fields" => [],
             ];
 
             foreach ($searchQuery->getHighlightFields() as $field) {

--- a/Search/Document.php
+++ b/Search/Document.php
@@ -281,7 +281,7 @@ class Document implements \JsonSerializable
             'url' => $this->url,
             'image_url' => $this->imageUrl,
             'locale' => $this->locale,
-            'highlight' => $this->highlight
+            'highlight' => $this->highlight,
         ];
     }
 }

--- a/Search/Document.php
+++ b/Search/Document.php
@@ -62,6 +62,11 @@ class Document implements \JsonSerializable
     protected $index;
 
     /**
+     * @var array
+     */
+    protected $highlight;
+
+    /**
      * @param Field $field
      */
     public function addField(Field $field)
@@ -248,6 +253,22 @@ class Document implements \JsonSerializable
     }
 
     /**
+     * @return array
+     */
+    public function getHighlight()
+    {
+        return $this->highlight;
+    }
+
+    /**
+     * @param array $highlight
+     */
+    public function setHighlight($highlight)
+    {
+        $this->highlight = $highlight;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function jsonSerialize()
@@ -260,6 +281,7 @@ class Document implements \JsonSerializable
             'url' => $this->url,
             'image_url' => $this->imageUrl,
             'locale' => $this->locale,
+            'highlight' => $this->highlight
         ];
     }
 }

--- a/Search/SearchQuery.php
+++ b/Search/SearchQuery.php
@@ -50,6 +50,11 @@ class SearchQuery
      */
     private $offset = 0;
 
+    /**
+     * @var array
+     */
+    private $highlightFields = [];
+
     public function __construct($queryString)
     {
         $this->queryString = $queryString;
@@ -160,5 +165,21 @@ class SearchQuery
     public function setOffset($offset)
     {
         $this->offset = $offset;
+    }
+
+    /**
+     * @return array
+     */
+    public function getHighlightFields()
+    {
+        return $this->highlightFields;
+    }
+
+    /**
+     * @param array $highlightFields
+     */
+    public function setHighlightFields($highlightFields)
+    {
+        $this->highlightFields = $highlightFields;
     }
 }

--- a/Search/SearchQueryBuilder.php
+++ b/Search/SearchQueryBuilder.php
@@ -118,7 +118,8 @@ class SearchQueryBuilder
     }
 
     /**
-     * Set which fields should be highlighted with search hits
+     * Set which fields should be highlighted with search hits.
+     *
      * @param array $highlight
      *
      * @return SearchQueryBuilder

--- a/Search/SearchQueryBuilder.php
+++ b/Search/SearchQueryBuilder.php
@@ -118,6 +118,19 @@ class SearchQueryBuilder
     }
 
     /**
+     * Set which fields should be highlighted with search hits
+     * @param array $highlight
+     *
+     * @return SearchQueryBuilder
+     */
+    public function highlight($highlight)
+    {
+        $this->searchQuery->setHighlightFields($highlight);
+
+        return $this;
+    }
+
+    /**
      * Execute the search.
      *
      * @return SearchResult


### PR DESCRIPTION
This adds the capability to specify an array of fields in the SearchQuery, which will be used to find context around search result "hits" (which seem to be called "highlight" in the searching world). The ElasticSearchAdapter then modifies the query to include configuration to return those highlights, and puts the returned highlight data from Elasticsearch into the SearchDocument.

Example usage looks like this:
```
$searchManager = $this->get('massive_search.search_manager');
$hits = $searchManager->createSearch($query)->index($index)->highlight(['title', 'summary', 'content'])->execute();
foreach ($hits as $hit) {
   $document = $hit->getDocument();
   $highlight = $document->getHighlight();
   // Do something with the highlight data
}
```

The highlight property on the document is an array and looks something like this:
```
[
   "fieldname1" => [
      "context around hit1 in fieldname1's content",
      "context around hit2 in fieldname1's content",
      ...
   ],
   "fieldname2" => [
      "context around hit1 in fieldname2's content",
      "context around hit2 in fieldname2's content",
      ...
   ],
   ...
]
```
If no hit happened in a field that was specified for highlighting, it won't be present in the result document's highlight array. If no hit happened in any of the fields, the highlight array will be empty.

Zend Lucene adapter also has capability for highlights, but this is not implemented in this PR.