### PR TITLE
Minor fix : elasticsearch _type

### DIFF
--- a/Search/Adapter/ElasticSearchAdapter.php
+++ b/Search/Adapter/ElasticSearchAdapter.php
@@ -306,7 +306,7 @@ class ElasticSearchAdapter implements AdapterInterface
             return 'massive_undefined';
         }
 
-        return substr(str_replace('\\', '_', $class), 1);
+        return ltrim(str_replace('\\', '_', $class), '_');
     }
 
     /**

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,16 @@
 # UPGRADE
 
+## dev-develop
+
+The _type field in Elasticsearch has been modified so it correctly reflects the fully qualified
+class name (FQCN) of the documents being indexed in snake case. When you are using Elasticsearch
+and upgrade, you will have to rebuild the indexes using the following command :
+
+```bash
+bin/console massive:search:reindex
+```
+
+
 ## 0.11.0
 
 ### IndexName decorators


### PR DESCRIPTION
When looking at the ElasticSearch indexes created with Sulu, I noticed that the _type field looked like this :
```      
{
        "_index" : "massive_page-fr-i18n",
        "_type" : "ulu_Bundle_ContentBundle_Document_HomeDocument",
        "_id" : "cc6738ef-7fe2-4707-ba3f-0e2dac854700",
        "_score" : 1.0,
        "_source" : {
          "excerptTitle" : "",
          ...
        }
} 
```

As you can see, the _type is missing the first letter. This PR fixes this (by stripping any preceding _ after converting the \ in the class names to _)...
