### PR TITLE
Update queryBuilder with result of custom repository method

### DIFF
--- a/Search/Reindex/Provider/DoctrineOrmProvider.php
+++ b/Search/Reindex/Provider/DoctrineOrmProvider.php
@@ -86,16 +86,14 @@ class DoctrineOrmProvider implements ReindexProviderInterface
         $queryBuilder = $repository->createQueryBuilder('d');
 
         if ($repositoryMethod) {
-            $result = $repository->$repositoryMethod($queryBuilder);
+            $queryBuilder = $repository->$repositoryMethod($queryBuilder);
 
-            if (is_array($result)) {
+            if (is_array($queryBuilder)) {
                 @trigger_error('Reindex repository methods should NOT return anything. Use the passed query builder instead.');
-                $this->cachedEntities = $result;
+                $this->cachedEntities = $queryBuilder;
 
                 return $this->sliceEntities($offset, $maxResults);
             }
-
-            $queryBuilder = $result;
         }
 
         $queryBuilder->setFirstResult($offset);

--- a/Search/Reindex/Provider/DoctrineOrmProvider.php
+++ b/Search/Reindex/Provider/DoctrineOrmProvider.php
@@ -94,7 +94,7 @@ class DoctrineOrmProvider implements ReindexProviderInterface
 
                 return $this->sliceEntities($offset, $maxResults);
             }
-            
+
             $queryBuilder = $result;
         }
 

--- a/Search/Reindex/Provider/DoctrineOrmProvider.php
+++ b/Search/Reindex/Provider/DoctrineOrmProvider.php
@@ -94,6 +94,8 @@ class DoctrineOrmProvider implements ReindexProviderInterface
 
                 return $this->sliceEntities($offset, $maxResults);
             }
+            
+            $queryBuilder = $result;
         }
 
         $queryBuilder->setFirstResult($offset);


### PR DESCRIPTION
When using a custom repository method, the result of the method is not currently used when returning a new QueryBuilder instance, which causes the custom query to be ignored. This patch updated the method to mimic what is done in the `getCount`