### PR TITLE
Add a note about using the QueryBuilder when using a custom repository method

### DIFF
--- a/Resources/docs/mapping.rst
+++ b/Resources/docs/mapping.rst
@@ -149,6 +149,13 @@ You can specify a specific method to use on the repository as follows:
 
     </massive-search-mapping>
 
+.. important::
+
+    The method will receive an instance of `QueryBuilder` as the first argument,
+    which can be used to construct the query, with `d` used as an alias.
+    The method should **not** return anything
+    
+    
 Full example
 ------------
 


### PR DESCRIPTION
The documentation is not clear about how to use a custom repository method, so I would like to add a note to indicate that the passed `QueryBuilder` instance should be used when constructing a query