### PR TITLE
Fix compatibility to php 7.2 and 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
       env:
         - PREFER=""
         - SYMFONY_DEPRECATIONS_HELPER=weak
-    - php: 7.0
+    - php: 7.3
       env:
         - PREFER=""
         - SYMFONY_DEPRECATIONS_HELPER=strong

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_install:
 
 before_script:
     - composer require elasticsearch/elasticsearch:^2.1 --dev --no-update
-    - composer update $PREFER
+    - composer update --prefer-dist $PREFER
     - elasticsearch-*/bin/elasticsearch -d
     - wget -q --waitretry=2 --retry-connrefused -T 20 -O - http://127.0.0.1:9200
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,17 @@ matrix:
       env:
         - PREFER="--prefer-lowest"
         - SYMFONY_DEPRECATIONS_HELPER=weak
+        - ENABLE_SWAP=true
     - php: 5.5
       env:
         - PREFER=""
         - SYMFONY_DEPRECATIONS_HELPER=weak
+        - ENABLE_SWAP=true
     - php: 5.6
       env:
         - PREFER=""
         - SYMFONY_DEPRECATIONS_HELPER=weak
+        - ENABLE_SWAP=true
     - php: 7.3
       env:
         - PREFER=""
@@ -29,6 +32,14 @@ matrix:
 before_install:
   - curl -L -o elasticsearch.zip ${ES_DOWNLOAD_URL}
   - ls -lah
+  - | # enable swap
+    if [[ $ENABLE_SWAP == 'true' ]]; then
+        sudo fallocate -l 4G /swapfile
+        sudo chmod 600 /swapfile
+        sudo mkswap /swapfile
+        sudo swapon /swapfile
+        sudo sysctl vm.swappiness=10
+    fi
   - unzip elasticsearch.zip
   - phpenv config-rm xdebug.ini
   - phpenv config-add Tests/travis.php.ini

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG
 =========
 
+* dev-master
+    * BUGFIX       #126 Fix compatibility to php 7.2
+
 * 0.17.0 (2018-09-25)
     * ENHANCEMENT  #124 Updated dependencies for symfony4 and fixed deprecations 
     * ENHANCEMENT  #114 Updated elasticsearch dependency

--- a/Search/ExpressionLanguage/MassiveSearchExpressionLanguage.php
+++ b/Search/ExpressionLanguage/MassiveSearchExpressionLanguage.php
@@ -69,7 +69,7 @@ class MassiveSearchExpressionLanguage extends ExpressionLanguage
                 throw new \Exception('Map function does not support compilation');
             },
             function (array $values, $elements, $expression) {
-                if (0 === count($elements)) {
+                if (empty($elements)) {
                     return [];
                 }
 

--- a/Tests/Unit/Command/ReindexCommandTest.php
+++ b/Tests/Unit/Command/ReindexCommandTest.php
@@ -73,8 +73,10 @@ class ReindexCommandTest extends \PHPUnit_Framework_TestCase
      */
     public function testEnvProdWarning()
     {
+        $this->resumeManager->getUnfinishedProviders()->willReturn([]);
         $this->providerRegistry->getProviders()->willReturn([]);
         $tester = $this->execute('dev', []);
+
         $this->assertContains('WARNING: You are running', $tester->getDisplay());
     }
 

--- a/Tests/travis.php.ini
+++ b/Tests/travis.php.ini
@@ -1,1 +1,1 @@
-memory_limit = 4096M
+memory_limit = -1


### PR DESCRIPTION
Currently it fails if elements is not from type array when using php >= 7.2