### PR TITLE
Custom repository method bugfix

### DIFF
--- a/Search/Reindex/Provider/DoctrineOrmProvider.php
+++ b/Search/Reindex/Provider/DoctrineOrmProvider.php
@@ -125,16 +125,16 @@ class DoctrineOrmProvider implements ReindexProviderInterface
         $queryBuilder = $repository->createQueryBuilder('d');
 
         if ($repositoryMethod) {
-            $queryBuilder = $repository->$repositoryMethod($queryBuilder);
-        }
+            $result = $repository->$repositoryMethod($queryBuilder);
 
-        if (!$queryBuilder instanceof QueryBuilder) {
-            @trigger_error(
-                'Reindex repository methods should NOT return anything. Use the passed query builder instead.'
-            );
+            if ($result) {
+                @trigger_error(
+                    'Reindex repository methods should NOT return anything. Use the passed query builder instead.'
+                );
 
-            $queryBuilder = $this->entityManager->createQueryBuilder()
-                ->from($classFqn, 'd');
+                $queryBuilder = $this->entityManager->createQueryBuilder()
+                    ->from($classFqn, 'd');
+            }
         }
 
         $queryBuilder->select('count(d.id)');

--- a/Search/Reindex/Provider/DoctrineOrmProvider.php
+++ b/Search/Reindex/Provider/DoctrineOrmProvider.php
@@ -13,7 +13,6 @@ namespace Massive\Bundle\SearchBundle\Search\Reindex\Provider;
 
 use Doctrine\Common\Persistence\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\QueryBuilder;
 use Massive\Bundle\SearchBundle\Search\Reindex\ReindexProviderInterface;
 use Metadata\MetadataFactory;
 


### PR DESCRIPTION
When specifying a custom repository method for reindex which does not return anything as per the documentation, the `DoctrineOrmProvider::getCount()` method rebuilds the query builder using the entity manager. This patch merely mitigates the behaviour so that custom repository methods that adhere to the documentation specification does not produce unexpected results.