### PR TITLE
Make massive test adapter public

### DIFF
--- a/Resources/config/search.xml
+++ b/Resources/config/search.xml
@@ -33,7 +33,7 @@
         </service>
 
         <!-- Adapters -->
-        <service id="massive_search.adapter.test" class="%massive_search.search.adapter.test.class%">
+        <service id="massive_search.adapter.test" class="%massive_search.search.adapter.test.class%" public="true">
             <argument type="service" id="massive_search.factory" />
         </service>
 


### PR DESCRIPTION
The [Elastic](https://github.com/massiveart/MassiveSearchBundle/blob/develop/Resources/config/adapter_elastic.xml#L20) and the [Zend](https://github.com/massiveart/MassiveSearchBundle/blob/develop/Resources/config/adapter_zendlucene.xml#L7) adapter are public services so the test adapter should also be public.