### PR TITLE
Use handcrafted in the alps fork for massive search zend lucene tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
         - PREFER=""
         - SYMFONY_DEPRECATIONS_HELPER=weak
         - ENABLE_SWAP=true
-    - php: 7.3
+    - php: 7.4
       env:
         - PREFER=""
         - SYMFONY_DEPRECATIONS_HELPER=strong
@@ -39,10 +39,10 @@ before_install:
         sudo chmod 600 /swapfile
         sudo mkswap /swapfile
         sudo swapon /swapfile
-        sudo sysctl vm.swappiness=10
+        sudo sysctl vm.swappiness=20
     fi
   - unzip elasticsearch.zip
-  - phpenv config-rm xdebug.ini
+  - phpenv config-rm xdebug.ini || true
   - phpenv config-add Tests/travis.php.ini
   - composer self-update
 

--- a/Tests/Unit/DependencyInjection/MassiveSearchExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/MassiveSearchExtensionTest.php
@@ -11,6 +11,7 @@
 
 namespace Massive\Bundle\SearchBundle\Unit\DependencyInjection;
 
+use Doctrine\Orm\EntityManager;
 use Massive\Bundle\SearchBundle\DependencyInjection\MassiveSearchExtension;
 use Massive\Bundle\SearchBundle\MassiveSearchBundle;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
@@ -28,6 +29,7 @@ class MassiveSearchExtensionTest extends AbstractExtensionTestCase
         $this->container->setParameter('kernel.debug', false);
         $this->container->register('event_dispatcher', EventDispatcher::class);
         $this->container->register('filesystem', Filesystem::class);
+        $this->container->register('doctrine.orm.entity_manager', EntityManager::class);
     }
 
     protected function getContainerExtensions()

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
     "require-dev": {
         "phpunit/phpunit": "^4.8 || ^5.7",
 
-        "zendframework/zend-stdlib": "2.3.1 as 2.0.0rc5",
-        "zendframework/zendsearch": "2.*@dev",
+        "handcraftedinthealps/zendsearch": "^2.0@dev",
         "elasticsearch/elasticsearch": "^2.1",
         "symfony-cmf/testing": "^1.3 || ^2.1",
         "symfony/symfony": "~2.7 || ~3.0 || ~4.0",
@@ -33,8 +32,7 @@
     },
     "suggest": {
         "sensio/distribution-bundle": "Required if the SearchScriptHandler is used",
-        "zendframework/zendsearch": "To use the PHP based Zend Search library (based on Lucene)",
-        "zendframework/zend-stdlib": "(dependency of zendsearch)",
+        "handcraftedinthealps/zendsearch": "To use the PHP based Zend Search library (based on Lucene)",
         "elasticsearch/elasticsearch": "To use Elasticsearch"
     },
     "autoload": {


### PR DESCRIPTION
Use handcrafted in the alps Zendsearch fork to avoid requreiments to zend stdlib and so use the newest version of libraries supporting php 7.4