### PR TITLE
Add support for elasticsearch 6 and 7

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -14,3 +14,4 @@ disabled:
     - blankline_after_open_tag
     - function_declaration
     - single_line_class_definition
+    - single_line_throw


### PR DESCRIPTION
Add support for elasticsearch 6.

Currently it will fail because elasticsearch 6 does not longer support multiple types per index. So if you now use elasticsearch 6 we will add a custom document type field and set the type to the index_name.