### PR TITLE
Fix the data presented in the exception while validating the query

### DIFF
--- a/Search/SearchManager.php
+++ b/Search/SearchManager.php
@@ -337,8 +337,8 @@ class SearchManager implements SearchManagerInterface
         if (false === empty($unknownIndexes)) {
             throw new Exception\SearchException(
                 sprintf(
-                    'Search indexes "%s" not known. Known indexes: "%s"',
-                    implode('", "', $queryIndexNames),
+                    'Search index or indexes "%s" not known. Known indexes: "%s"',
+                    implode('", "', $unknownIndexes),
                     implode('", "', $indexNames)
                 )
             );

--- a/Tests/Features/general.feature
+++ b/Tests/Features/general.feature
@@ -106,7 +106,7 @@ Feature: Search Manager
         ]
         """
         When I search for "foo" in index "barbarbar"
-        Then an exception with message 'Search indexes "barbarbar" not known. Known indexes: "car"' should be thrown
+        Then an exception with message 'Search index or indexes "barbarbar" not known. Known indexes: "car"' should be thrown
 
     Scenario: Search returns documents
         Given the following "Car" objects have been indexed


### PR DESCRIPTION
Before the exception reports all used indexes not found, even if they exist.