### PR TITLE
Use string instead of parameter in massive search bundle

### DIFF
--- a/Resources/config/search.xml
+++ b/Resources/config/search.xml
@@ -77,12 +77,12 @@
         <service id="massive_search.events.index_listener" class="Massive\Bundle\SearchBundle\Search\EventListener\IndexListener">
             <argument type="service" id="massive_search.search_manager"/>
 
-            <tag name="kernel.event_listener" event="%massive_search.events.index%" method="onIndex"/>
+            <tag name="kernel.event_listener" event="massive_search.index" method="onIndex"/>
         </service>
         <service id="massive_search.events.deindex_listener" class="Massive\Bundle\SearchBundle\Search\EventListener\DeindexListener">
             <argument type="service" id="massive_search.search_manager"/>
 
-            <tag name="kernel.event_listener" event="%massive_search.events.deindex%" method="onDeindex"/>
+            <tag name="kernel.event_listener" event="massive_search.deindex" method="onDeindex"/>
         </service>
 
         <!-- Reindex -->


### PR DESCRIPTION
Currently lint:container fails because of: https://github.com/symfony/symfony/issues/37166.

Inlining the [events](https://github.com/massiveart/MassiveSearchBundle/blob/2.2.2/Search/SearchEvents.php). 