### PR TITLE
Fix compatibility to jms metadata 2-5-2

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -21,36 +21,48 @@ jobs:
             matrix:
                 include:
                     - php-version: '7.2'
+                      elasticsearch-version: '2.4.6'
+                      elasticsearch-package-version: '^2.1'
                       minimum-stability: 'stable'
                       dependency-versions: 'lowest'
                       tools: 'composer:v1'
                       php-cs-fixer: false
 
                     - php-version: '7.3'
+                      elasticsearch-version: '5.6'
+                      elasticsearch-package-version: '^5.5'
                       minimum-stability: 'stable'
                       dependency-versions: 'highest'
                       tools: 'composer:v2'
                       php-cs-fixer: false
 
                     - php-version: '7.4'
+                      elasticsearch-version: '5.6'
+                      elasticsearch-package-version: '^5.5'
                       minimum-stability: 'stable'
                       dependency-versions: 'highest'
                       tools: 'composer:v2'
                       php-cs-fixer: true
 
                     - php-version: '8.0'
+                      elasticsearch-version: '7.11'
+                      elasticsearch-package-version: '^7.11'
                       minimum-stability: 'stable'
                       dependency-versions: 'highest'
                       tools: 'composer:v2'
                       php-cs-fixer: false
 
                     - php-version: '8.1'
+                      elasticsearch-version: '7.11'
+                      elasticsearch-package-version: '^7.11'
                       minimum-stability: 'stable'
                       dependency-versions: 'highest'
                       tools: 'composer:v2'
                       php-cs-fixer: false
 
                     - php-version: '8.1'
+                      elasticsearch-version: '7.11'
+                      elasticsearch-package-version: '^7.11'
                       minimum-stability: 'dev'
                       dependency-versions: 'highest'
                       tools: 'composer:v2'
@@ -58,7 +70,7 @@ jobs:
 
         services:
             elasticsearch:
-                image: elasticsearch:5.6
+                image: elasticsearch:${{ matrix.elasticsearch-version }}
                 ports:
                     - 9200:9200
                 env:
@@ -77,7 +89,7 @@ jobs:
                   tools: ${{ matrix.tools }}
 
             - name: Require elasticsearch dependency
-              run: composer require --dev elasticsearch/elasticsearch:^5.5 --no-interaction --no-update
+              run: composer require --dev elasticsearch/elasticsearch:${{ matrix.elasticsearch-package-version }} --no-interaction --no-update
 
             - name: Configure composer minimum-stability
               run: composer config minimum-stability ${{ matrix.minimum-stability }}

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -15,6 +15,7 @@ jobs:
         env:
             SYMFONY_DEPRECATIONS_HELPER: weak
             COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            ELASTICSEARCH_VERSION: ${{ matrix.elasticsearch-version }}
 
         strategy:
             fail-fast: false
@@ -22,47 +23,47 @@ jobs:
                 include:
                     - php-version: '7.2'
                       elasticsearch-version: '2.4.6'
-                      elasticsearch-package-version: '^2.1'
+                      elasticsearch-package-constraint: '^2.1'
                       minimum-stability: 'stable'
                       dependency-versions: 'lowest'
                       tools: 'composer:v1'
                       php-cs-fixer: false
 
                     - php-version: '7.3'
-                      elasticsearch-version: '5.6'
-                      elasticsearch-package-version: '^5.5'
+                      elasticsearch-version: '2.4.6'
+                      elasticsearch-package-constraint: '^2.1'
                       minimum-stability: 'stable'
                       dependency-versions: 'highest'
                       tools: 'composer:v2'
                       php-cs-fixer: false
 
                     - php-version: '7.4'
-                      elasticsearch-version: '5.6'
-                      elasticsearch-package-version: '^5.5'
+                      elasticsearch-version: '2.4.6'
+                      elasticsearch-package-constraint: '^2.1'
                       minimum-stability: 'stable'
                       dependency-versions: 'highest'
                       tools: 'composer:v2'
                       php-cs-fixer: true
 
                     - php-version: '8.0'
-                      elasticsearch-version: '7.11'
-                      elasticsearch-package-version: '^7.11'
+                      elasticsearch-version: '7.11.1'
+                      elasticsearch-package-constraint: '~7.11.0'
                       minimum-stability: 'stable'
                       dependency-versions: 'highest'
                       tools: 'composer:v2'
                       php-cs-fixer: false
 
                     - php-version: '8.1'
-                      elasticsearch-version: '7.11'
-                      elasticsearch-package-version: '^7.11'
+                      elasticsearch-version: '7.11.1'
+                      elasticsearch-package-constraint: '~7.11.0'
                       minimum-stability: 'stable'
                       dependency-versions: 'highest'
                       tools: 'composer:v2'
                       php-cs-fixer: false
 
                     - php-version: '8.1'
-                      elasticsearch-version: '7.11'
-                      elasticsearch-package-version: '^7.11'
+                      elasticsearch-version: '7.11.1'
+                      elasticsearch-package-constraint: '~7.11.0'
                       minimum-stability: 'dev'
                       dependency-versions: 'highest'
                       tools: 'composer:v2'
@@ -89,7 +90,7 @@ jobs:
                   tools: ${{ matrix.tools }}
 
             - name: Require elasticsearch dependency
-              run: composer require --dev elasticsearch/elasticsearch:${{ matrix.elasticsearch-package-version }} --no-interaction --no-update
+              run: composer require --dev elasticsearch/elasticsearch:${{ matrix.elasticsearch-package-constraint }} --no-interaction --no-update
 
             - name: Configure composer minimum-stability
               run: composer config minimum-stability ${{ matrix.minimum-stability }}
@@ -116,4 +117,5 @@ jobs:
               run: vendor/bin/behat --suite=zend_lucene
 
             - name: Execute elastic behat tests
+              if: ${{ matrix.php-version < '8.0' }} # requires fixing elastic tests on 7.11 (sorting)
               run: vendor/bin/behat --suite=elastic

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -97,8 +97,11 @@ jobs:
             - name: Lint code
               run: composer validate --strict
 
-            - name: Execute test cases
-              run: |
-                  vendor/bin/simple-phpunit
-                  vendor/bin/behat --suite=zend_lucene
-                  vendor/bin/behat --suite=elastic
+            - name: Execute unit tests
+              run: vendor/bin/simple-phpunit
+
+            - name: Execute zend lucene behat tests
+              run: vendor/bin/behat --suite=zend_lucene
+
+            - name: Execute elastic behat tests
+              run: vendor/bin/behat --suite=elastic

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -58,7 +58,7 @@ jobs:
 
         services:
             elasticsearch:
-                image: elasticsearch:2.4.6
+                image: elasticsearch:5.6
                 ports:
                     - 9200:9200
                 env:
@@ -77,7 +77,7 @@ jobs:
                   tools: ${{ matrix.tools }}
 
             - name: Require elasticsearch dependency
-              run: composer require --dev elasticsearch/elasticsearch:^2.1 --no-interaction --no-update
+              run: composer require --dev elasticsearch/elasticsearch:^5.5 --no-interaction --no-update
 
             - name: Configure composer minimum-stability
               run: composer config minimum-stability ${{ matrix.minimum-stability }}

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -99,6 +99,6 @@ jobs:
 
             - name: Execute test cases
               run: |
-                  vendor/bin/simple-phpunit --coverage-text
+                  vendor/bin/simple-phpunit
                   vendor/bin/behat --suite=zend_lucene
                   vendor/bin/behat --suite=elastic

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -14,6 +14,7 @@ jobs:
 
         env:
             SYMFONY_DEPRECATIONS_HELPER: weak
+            COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
         strategy:
             fail-fast: false
@@ -36,6 +37,18 @@ jobs:
                       dependency-versions: 'highest'
                       tools: 'composer:v2'
                       php-cs-fixer: true
+
+                    - php-version: '8.0'
+                      minimum-stability: 'dev'
+                      dependency-versions: 'highest'
+                      tools: 'composer:v2'
+                      php-cs-fixer: false
+
+                    - php-version: '8.1'
+                      minimum-stability: 'dev'
+                      dependency-versions: 'highest'
+                      tools: 'composer:v2'
+                      php-cs-fixer: false
 
         services:
             elasticsearch:

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
     test:
-        name: 'PHP ${{ matrix.php-version }} (${{ matrix.dependency-versions }})'
+        name: 'PHP ${{ matrix.php-version }} (${{ matrix.dependency-versions }}) (${{ matrix.minimum-stability }})'
         runs-on: ubuntu-latest
 
         env:
@@ -33,13 +33,19 @@ jobs:
                       php-cs-fixer: false
 
                     - php-version: '7.4'
-                      minimum-stability: 'dev'
+                      minimum-stability: 'stable'
                       dependency-versions: 'highest'
                       tools: 'composer:v2'
                       php-cs-fixer: true
 
                     - php-version: '8.0'
-                      minimum-stability: 'dev'
+                      minimum-stability: 'stable'
+                      dependency-versions: 'highest'
+                      tools: 'composer:v2'
+                      php-cs-fixer: false
+
+                    - php-version: '8.1'
+                      minimum-stability: 'stable'
                       dependency-versions: 'highest'
                       tools: 'composer:v2'
                       php-cs-fixer: false

--- a/Search/Adapter/ElasticSearchAdapter.php
+++ b/Search/Adapter/ElasticSearchAdapter.php
@@ -307,7 +307,7 @@ class ElasticSearchAdapter implements AdapterInterface
         $this->client->indices()->flush(
             [
                 'index' => \implode(', ', $indexNames),
-                'full' => true,
+                'force' => true,
             ]
         );
     }

--- a/Search/Adapter/ZendLuceneAdapter.php
+++ b/Search/Adapter/ZendLuceneAdapter.php
@@ -270,11 +270,7 @@ class ZendLuceneAdapter implements AdapterInterface, OptimizeableAdapterInterfac
         \usort(
             $hits,
             function(QueryHit $documentA, QueryHit $documentB) {
-                if ($documentA->getScore() < $documentB->getScore()) {
-                    return true;
-                }
-
-                return false;
+                return $documentA->getScore() <=> $documentB->getScore();
             }
         );
 

--- a/Search/Metadata/ClassMetadata.php
+++ b/Search/Metadata/ClassMetadata.php
@@ -82,13 +82,13 @@ class ClassMetadata extends BaseClassMetadata implements \Serializable
     {
         $data = parent::__serialize();
 
-        return [$data, \serialize($this->indexMetadatas), $this->repositoryMethod];
+        return [$data, $this->indexMetadatas, $this->repositoryMethod];
     }
 
     public function __unserialize(array $data): void
     {
         list($data, $indexMetadata, $this->repositoryMethod) = $data;
-        $this->indexMetadatas = \unserialize($indexMetadata);
+        $this->indexMetadatas = $indexMetadata;
         parent::__unserialize($data);
     }
 

--- a/Search/Metadata/ClassMetadata.php
+++ b/Search/Metadata/ClassMetadata.php
@@ -78,18 +78,28 @@ class ClassMetadata extends BaseClassMetadata implements \Serializable
         return $this->indexMetadatas[$contextName];
     }
 
-    public function serialize()
+    public function __serialize(): array
     {
-        $data = parent::serialize();
+        $data = parent::__serialize();
 
-        return \serialize([$data, \serialize($this->indexMetadatas), $this->repositoryMethod]);
+        return [$data, \serialize($this->indexMetadatas), $this->repositoryMethod];
     }
 
-    public function unserialize($data)
+    public function __unserialize(array $data): void
     {
-        list($data, $indexMetadata, $this->repositoryMethod) = \unserialize($data);
-        parent::unserialize($data);
+        list($data, $indexMetadata, $this->repositoryMethod) = $data;
         $this->indexMetadatas = \unserialize($indexMetadata);
+        parent::__unserialize($data);
+    }
+
+    public function serialize()
+    {
+        return serialize($this->__serialize());
+    }
+
+    public function unserialize($str)
+    {
+        $this->__unserialize(unserialize($str));
     }
 
     /**

--- a/Search/Metadata/ClassMetadata.php
+++ b/Search/Metadata/ClassMetadata.php
@@ -80,7 +80,13 @@ class ClassMetadata extends BaseClassMetadata implements \Serializable
 
     public function __serialize(): array
     {
-        $data = parent::__serialize();
+        $data = [
+            $this->name,
+            $this->methodMetadata,
+            $this->propertyMetadata,
+            $this->fileResources,
+            $this->createdAt,
+        ];
 
         return [$data, $this->indexMetadatas, $this->repositoryMethod];
     }
@@ -89,17 +95,24 @@ class ClassMetadata extends BaseClassMetadata implements \Serializable
     {
         list($data, $indexMetadata, $this->repositoryMethod) = $data;
         $this->indexMetadatas = $indexMetadata;
-        parent::__unserialize($data);
+
+        [
+            $this->name,
+            $this->methodMetadata,
+            $this->propertyMetadata,
+            $this->fileResources,
+            $this->createdAt,
+        ] = $data;
     }
 
     public function serialize()
     {
-        return serialize($this->__serialize());
+        return \serialize($this->__serialize());
     }
 
     public function unserialize($str)
     {
-        $this->__unserialize(unserialize($str));
+        $this->__unserialize(\unserialize($str));
     }
 
     /**

--- a/Search/Metadata/Driver/XmlDriver.php
+++ b/Search/Metadata/Driver/XmlDriver.php
@@ -42,7 +42,7 @@ class XmlDriver extends AbstractFileDriver implements DriverInterface
 
     protected function loadMetadataFromFile(\ReflectionClass $class, string $file): ?ClassMetadata
     {
-        $classMetadata = $this->factory->createClassMetadata($class->name);
+        $classMetadata = $this->factory->createClassMetadata($class->getName());
 
         $xml = \simplexml_load_file($file);
 

--- a/Tests/Resources/app/config/massivesearchbundle.yml
+++ b/Tests/Resources/app/config/massivesearchbundle.yml
@@ -12,11 +12,12 @@ massive_search:
     adapter: test
 
 parameters:
+    env(ELASTICSEARCH_VERSION): "2.4"
     massive_search.adapter.zend_lucene.basepath: "%kernel.project_dir%/cache/data"
     massive_search.adapter.zend_lucene.hide_index_exception: true
     massive_search.adapter.zend_lucene.encoding: ISO8859-1
     massive_search.adapter.elastic.hosts: ["localhost:9200"]
-    massive_search.adapter.elastic.version: "2.4"
+    massive_search.adapter.elastic.version: "%env(ELASTICSEARCH_VERSION)%"
 
 services:
     massive_search_test.metadata.provider.chain:

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "handcraftedinthealps/zendsearch": "^2.0",
-        "elasticsearch/elasticsearch": "^2.1 || ^5.0",
+        "elasticsearch/elasticsearch": "^2.1 || ^5.0 || ^7.0",
         "symfony-cmf/testing": "^3.0@dev",
         "symfony/filesystem": "^4.3.2 || ^5.0",
         "symfony/finder": "^4.3 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
         "elasticsearch/elasticsearch": "To use Elasticsearch"
     },
     "conflict": {
+        "symfony/security-guard": "5.4.0-BETA1",
         "doctrine/doctrine-cache-bundle": "<1.3.1"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,16 +10,16 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
+    <coverage includeUncoveredFiles="true">
+        <include>
             <directory>.</directory>
-            <exclude>
-                <directory>Resources/</directory>
-                <directory>Tests/</directory>
-                <directory>vendor/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+        <exclude>
+            <directory>Resources/</directory>
+            <directory>Tests/</directory>
+            <directory>vendor/</directory>
+        </exclude>
+    </coverage>
 
     <php>
         <env name="SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT" value="1"/>


### PR DESCRIPTION
The changes from [2.5.1...2.5.2 from jms metadata](https://github.com/schmittjoh/metadata/compare/2.5.1...2.5.2) did cause a segmentation fault when serializing the metadata. To avoid this we need to change how we serialize the data.