### PR TITLE
Fix sorting of zend lucene adapter for multi index searcher

### DIFF
--- a/Search/Adapter/ZendLuceneAdapter.php
+++ b/Search/Adapter/ZendLuceneAdapter.php
@@ -270,7 +270,7 @@ class ZendLuceneAdapter implements AdapterInterface, OptimizeableAdapterInterfac
         \usort(
             $hits,
             function(QueryHit $documentA, QueryHit $documentB) {
-                return $documentA->getScore() <=> $documentB->getScore();
+                return $documentB->getScore() <=> $documentA->getScore();
             }
         );
 


### PR DESCRIPTION
An accidently change to spaceship operator did sort the pages falsly https://github.com/massiveart/MassiveSearchBundle/pull/163. Effected version are 2.6.3 and 2.6.4:
