### PR TITLE
Store block values in one field

### DIFF
--- a/Search/Factory.php
+++ b/Search/Factory.php
@@ -79,9 +79,9 @@ class Factory
         return new MetadataField($name);
     }
 
-    public function createMetadataProperty($path)
+    public function createMetadataProperty($path, $condition = null)
     {
-        return new Property($path);
+        return new Property($path, $condition);
     }
 
     public function createMetadataValue($value)
@@ -89,8 +89,8 @@ class Factory
         return new Value($value);
     }
 
-    public function createMetadataExpression($expression)
+    public function createMetadataExpression($expression, $condition = null)
     {
-        return new Expression($expression);
+        return new Expression($expression, $condition);
     }
 }

--- a/Search/Metadata/Field/Expression.php
+++ b/Search/Metadata/Field/Expression.php
@@ -25,11 +25,17 @@ class Expression implements FieldInterface
     private $expression;
 
     /**
+     * @var string|null
+     */
+    private $condition;
+
+    /**
      * @param string $expression
      */
-    public function __construct($expression)
+    public function __construct($expression, $condition = null)
     {
         $this->expression = $expression;
+        $this->condition = $condition;
     }
 
     /**
@@ -40,5 +46,10 @@ class Expression implements FieldInterface
     public function getExpression()
     {
         return $this->expression;
+    }
+
+    public function getCondition()
+    {
+        return $this->condition;
     }
 }

--- a/Search/Metadata/Field/Property.php
+++ b/Search/Metadata/Field/Property.php
@@ -25,11 +25,17 @@ class Property implements FieldInterface
     private $property;
 
     /**
+     * @var mixed|null
+     */
+    private $condition;
+
+    /**
      * @param mixed $property
      */
-    public function __construct($property)
+    public function __construct($property, $condition = null)
     {
         $this->property = $property;
+        $this->condition = $condition;
     }
 
     /**
@@ -40,5 +46,10 @@ class Property implements FieldInterface
     public function getProperty()
     {
         return $this->property;
+    }
+
+    public function getCondition()
+    {
+        return $this->condition;
     }
 }

--- a/Search/Metadata/FieldEvaluator.php
+++ b/Search/Metadata/FieldEvaluator.php
@@ -70,6 +70,18 @@ class FieldEvaluator
         ));
     }
 
+    public function evaluateCondition($object, string $condition)
+    {
+        try {
+            return $this->expressionLanguage->evaluate($condition, $object);
+        } catch (\Exception $e) {
+            throw new \RuntimeException(\sprintf(
+                'Error encountered when evaluating expression "%s"',
+                $condition
+            ), null, $e);
+        }
+    }
+
     /**
      * Evaluate a property (using PropertyAccess).
      *

--- a/Search/ObjectToDocumentConverter.php
+++ b/Search/ObjectToDocumentConverter.php
@@ -131,7 +131,7 @@ class ObjectToDocumentConverter
      * @param mixed $object
      * @param array $fieldMapping
      * @param string[] $blockValues
-     * @param string $prefix
+     * @param string $prefix Prefix the document field name (used when called recursively)
      *
      * @throws \InvalidArgumentException
      */
@@ -182,7 +182,7 @@ class ObjectToDocumentConverter
             /** @var FieldInterface $mappingField */
             $mappingField = $mapping['field'];
             $condition = method_exists($mappingField, 'getCondition') ? $mappingField->getCondition() : null;
-            $validField = $condition ? $this->fieldEvaluator->evaluateCondition($object, $condition) : false;
+            $validField = $condition ? $this->fieldEvaluator->evaluateCondition($object, $condition) : true;
 
             if (false === $validField) {
                 continue;
@@ -223,7 +223,7 @@ class ObjectToDocumentConverter
                 continue;
             }
 
-            if ('complex' !== $mapping['type'] && $value) {
+            if ('complex' !== $mapping['type']) {
                 if ($isBlockScope && $value && Field::TYPE_STRING === $type) {
                     $blockValues[$prefix . $fieldName][] = $value;
                 } elseif (!$isBlockScope) {
@@ -233,15 +233,13 @@ class ObjectToDocumentConverter
                 continue;
             }
 
-            if ($value) {
-                foreach ($value as $key => $itemValue) {
-                    $itemType = $mapping['type'];
+            foreach ($value as $key => $itemValue) {
+                $itemType = $mapping['type'];
 
-                    if ($isBlockScope && $itemValue && Field::TYPE_STRING === $itemType) {
-                        $blockValues[$prefix . $fieldName . $key][] = $itemValue;
-                    } elseif (!$isBlockScope) {
-                        $this->addDocumentField($document, $fieldName . $key, $itemValue, $mapping, $itemType);
-                    }
+                if ($isBlockScope && $itemValue && Field::TYPE_STRING === $itemType) {
+                    $blockValues[$prefix . $fieldName . $key][] = $itemValue;
+                } elseif (!$isBlockScope) {
+                    $this->addDocumentField($document, $fieldName . $key, $itemValue, $mapping, $itemType);
                 }
             }
         }

--- a/Search/ObjectToDocumentConverter.php
+++ b/Search/ObjectToDocumentConverter.php
@@ -213,7 +213,7 @@ class ObjectToDocumentConverter
             if ('complex' !== $mapping['type']) {
                 if ($isBlockScope && $value && Field::TYPE_STRING === $type) {
                     $this->blockValues[] = strip_tags($value);
-                } elseif ($value) {
+                } elseif (!$isBlockScope) {
                     $this->addDocumentField($document, $fieldName, $value, $mapping, $type);
                 }
 

--- a/Search/ObjectToDocumentConverter.php
+++ b/Search/ObjectToDocumentConverter.php
@@ -120,7 +120,7 @@ class ObjectToDocumentConverter
 
         // Adds the merged data of each content-block (even nested-blocks) to the document.
         if (0 < count($this->blockValues)) {
-            $mapping = $this->addDefaultMappingOptions();
+            $mapping = $this->addMappingOptions();
             $blockValues = implode(' ', $this->blockValues);
             $this->addDocumentField($document, 'contentBlocks', $blockValues, $mapping, Field::TYPE_STRING);
         }
@@ -143,7 +143,7 @@ class ObjectToDocumentConverter
     {
         foreach ($fieldMapping as $fieldName => $mapping) {
             $this->hasRequiredMapping($document, $mapping);
-            $mapping = $this->addDefaultMappingOptions($mapping);
+            $mapping = $this->addMappingOptions($mapping);
 
             if ('complex' == $mapping['type']) {
                 if (!isset($mapping['mapping'])) {
@@ -226,7 +226,10 @@ class ObjectToDocumentConverter
         }
     }
 
-    private function addDefaultMappingOptions($mapping = []): array
+    /**
+     * Adds some default mapping options to the given array.
+     */
+    private function addMappingOptions($mapping = []): array
     {
         return \array_merge(
             [
@@ -239,6 +242,8 @@ class ObjectToDocumentConverter
     }
 
     /**
+     * Adds a search field to the Document.
+     *
      * @param Document $document
      * @param string $fieldName
      * @param mixed $value
@@ -264,6 +269,8 @@ class ObjectToDocumentConverter
     }
 
     /**
+     * Checks if all mandatory options are available in the given mapping.
+     *
      * @param Document $document
      * @param array $mapping
      */

--- a/Search/ObjectToDocumentConverter.php
+++ b/Search/ObjectToDocumentConverter.php
@@ -119,9 +119,9 @@ class ObjectToDocumentConverter
         $this->populateDocument($document, $object, $fieldMapping);
 
         // Adds the merged data of each content-block (even nested-blocks) to the document.
-        if (0 < count($this->blockValues)) {
+        if (0 < \count($this->blockValues)) {
             $mapping = $this->addMappingOptions();
-            $blockValues = implode(' ', $this->blockValues);
+            $blockValues = \implode(' ', $this->blockValues);
             $this->addDocumentField($document, 'contentBlocks', $blockValues, $mapping, Field::TYPE_STRING);
         }
 
@@ -212,7 +212,7 @@ class ObjectToDocumentConverter
 
             if ('complex' !== $mapping['type']) {
                 if ($isBlockScope && $value && Field::TYPE_STRING === $type) {
-                    $this->blockValues[] = strip_tags($value);
+                    $this->blockValues[] = \strip_tags($value);
                 } elseif (!$isBlockScope) {
                     $this->addDocumentField($document, $fieldName, $value, $mapping, $type);
                 }
@@ -252,7 +252,7 @@ class ObjectToDocumentConverter
      */
     private function addDocumentField($document, $fieldName, $value, $mapping, $type = null): void
     {
-        if (null === $type && array_key_exists('type', $mapping)) {
+        if (null === $type && \array_key_exists('type', $mapping)) {
             $type = $mapping['type'];
         }
 

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
 
         "behat/behat": "^3.4.2",
 
-        "webmozart/assert": "^1.7"
+        "webmozart/assert": "^1.7",
+        "phpspec/prophecy": "^1.15"
     },
     "suggest": {
         "sensio/distribution-bundle": "Required if the SearchScriptHandler is used",


### PR DESCRIPTION
## Problem

When at least one property inside a block (or nested block) had a search tag, a new field for each of the properties was created.

With the ElasticSearch adapter, this could lead to following error:
```
Limit of total fields [1000] has been exceeded
```

## Solution

This Pull Request collects only the tagged properties inside blocks (or nested blocks) and stores these values in one field called `contentBlocks`.

## Solves following issue
https://github.com/sulu/sulu/issues/6501

## Related PR

https://github.com/sulu/sulu/pull/6868