### PR TITLE
Add support for Elasticsearch 8 via Elasticsearch 7 client compatibility mode

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -61,6 +61,14 @@ jobs:
                       tools: 'composer:v2'
                       php-cs-fixer: false
 
+                    - php-version: '8.5'
+                      elasticsearch-version: '8.14.3'
+                      elasticsearch-package-constraint: '~7.17.0'
+                      minimum-stability: 'dev'
+                      dependency-versions: 'highest'
+                      tools: 'composer:v2'
+                      php-cs-fixer: false
+
         services:
             elasticsearch:
                 image: elasticsearch:${{ matrix.elasticsearch-version }}
@@ -91,6 +99,7 @@ jobs:
               uses: ramsey/composer-install@v1
               with:
                   dependency-versions: ${{matrix.dependency-versions}}
+                  composer-versions: ${{matrix.composer-options}}
 
             - name: Run php-cs-fixer
               if: ${{ matrix.php-cs-fixer }}

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -99,7 +99,6 @@ jobs:
               uses: ramsey/composer-install@v1
               with:
                   dependency-versions: ${{matrix.dependency-versions}}
-                  composer-versions: ${{matrix.composer-options}}
 
             - name: Run php-cs-fixer
               if: ${{ matrix.php-cs-fixer }}

--- a/Resources/config/adapter_elastic.xml
+++ b/Resources/config/adapter_elastic.xml
@@ -15,6 +15,7 @@
 
             <argument type="collection">
                 <argument key="hosts">%massive_search.adapter.elastic.hosts%</argument>
+                <argument key="version">%massive_search.adapter.elastic.version%</argument>
             </argument>
         </service>
         <service id="massive_search.adapter.elastic" class="%massive_search.search.adapter.elastic.class%" public="true">

--- a/Search/Adapter/Elastic/ClientFactory.php
+++ b/Search/Adapter/Elastic/ClientFactory.php
@@ -28,6 +28,22 @@ class ClientFactory
      */
     public static function create($config)
     {
-        return ClientBuilder::create()->setHosts($config['hosts'])->build();
+        $clientBuilder = ClientBuilder::create()->setHosts($config['hosts']);
+
+        $elasticSearchVersion = defined(Client::class . '::VERSION') ? Client::VERSION : '5.0';
+        $version = $config['version'] ?? $elasticSearchVersion;
+
+        if (\version_compare($version, '7.11.0', '>=')) {
+            $clientBuilder->setConnectionParams([
+                'client' => [
+                    'headers' => [
+                        'Accept' => ['application/vnd.elasticsearch+json;compatible-with=7'],
+                        'Content-Type' => ['application/vnd.elasticsearch+json;compatible-with=7'],
+                    ],
+                ],
+            ]);
+        }
+
+        return $clientBuilder->build();
     }
 }

--- a/Search/Adapter/ElasticSearchAdapter.php
+++ b/Search/Adapter/ElasticSearchAdapter.php
@@ -85,17 +85,6 @@ class ElasticSearchAdapter implements AdapterInterface
         $this->client = $client;
         $this->version = $version;
         $this->refresh = $refresh;
-
-        if (\version_compare($this->version, '7.11.0', '>=')) {
-            $client->setConnectionParams([
-                'client' => [
-                    'headers' => [
-                        'Accept' => ['application/vnd.elasticsearch+json;compatible-with=7'],
-                        'Content-Type' => ['application/vnd.elasticsearch+json;compatible-with=7'],
-                    ],
-                ],
-            ]);
-        }
     }
 
     public function index(Document $document, $indexName)

--- a/Search/Adapter/ElasticSearchAdapter.php
+++ b/Search/Adapter/ElasticSearchAdapter.php
@@ -85,6 +85,17 @@ class ElasticSearchAdapter implements AdapterInterface
         $this->client = $client;
         $this->version = $version;
         $this->refresh = $refresh;
+
+        if (\version_compare($this->version, '7.11.0', '>=')) {
+            $client->setConnectionParams([
+                'client' => [
+                    'headers' => [
+                        'Accept' => ['application/vnd.elasticsearch+json;compatible-with=7'],
+                        'Content-Type' => ['application/vnd.elasticsearch+json;compatible-with=7'],
+                    ],
+                ],
+            ]);
+        }
     }
 
     public function index(Document $document, $indexName)

--- a/Tests/docker/docker-elasticsearch-8-19.yml
+++ b/Tests/docker/docker-elasticsearch-8-19.yml
@@ -1,0 +1,19 @@
+services:
+    elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:8.19.0
+        environment:
+            discovery.type: single-node
+            xpack.security.enabled: 'false'
+            cluster.routing.allocation.disk.threshold_enabled: 'false'
+        ports:
+            - "9200:9200"
+        healthcheck:
+            test: ["CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1"]
+            interval: 5s
+            timeout: 5s
+            retries: 20
+        volumes:
+            - elasticsearch-data:/usr/share/elasticsearch/data
+
+volumes:
+    elasticsearch-data:

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,8 @@
     "conflict": {
         "guzzlehttp/ringphp": "< 1.0.7",
         "symfony/security-guard": "5.4.0-BETA1",
-        "doctrine/doctrine-cache-bundle": "<1.3.1"
+        "doctrine/doctrine-cache-bundle": "<1.3.1",
+        "elasticsearch/elasticsearch": "<2.0 || >=8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
<details><summary>fixed issue</summary>

TODO following red are failing but not failing with elasticsearch 7. The client still is ES 7.

<img width="1432" alt="Bildschirmfoto 2023-04-13 um 01 21 01" src="https://user-images.githubusercontent.com/1698337/231606899-6b299769-19e6-42da-8298-ed3f0ad6c52c.png">

</details>