### PR TITLE
Fix MassiveSearchExpressionLanguage with object/stdClass for block settings

### DIFF
--- a/Search/ExpressionLanguage/MassiveSearchExpressionLanguage.php
+++ b/Search/ExpressionLanguage/MassiveSearchExpressionLanguage.php
@@ -14,6 +14,7 @@ namespace Massive\Bundle\SearchBundle\Search\ExpressionLanguage;
 use Symfony\Component\ExpressionLanguage\ExpressionFunction;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
+use Symfony\Component\PropertyAccess\Exception\NoSuchIndexException;
 
 /**
  * Expression language for massive search bundle.
@@ -104,9 +105,15 @@ class MassiveSearchExpressionLanguage extends ExpressionLanguage
                 throw new \Exception('Value function does not support compilation');
             },
             function(array $values, $propertyPath, $default = null) use ($accessor) {
-                $value = $accessor->getValue($values, $propertyPath);
-                if (null !== $value) {
-                    return $value;
+                try {
+                    $value = $accessor->getValue($values, $propertyPath);
+                    if (null !== $value) {
+                        return $value;
+                    }
+                } catch (NoSuchIndexException $e) {
+                    // settings can be stdClass as it needs to convert to {} instead of [] for frontend
+                    // currently NoSuchIndexException will be thrown which we need to catch here and
+                    // return the default value
                 }
 
                 return $default;

--- a/Search/ExpressionLanguage/MassiveSearchExpressionLanguage.php
+++ b/Search/ExpressionLanguage/MassiveSearchExpressionLanguage.php
@@ -13,8 +13,8 @@ namespace Massive\Bundle\SearchBundle\Search\ExpressionLanguage;
 
 use Symfony\Component\ExpressionLanguage\ExpressionFunction;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
-use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\PropertyAccess\Exception\NoSuchIndexException;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
 
 /**
  * Expression language for massive search bundle.


### PR DESCRIPTION
Fixes search reindex for ArticleDocument and PageDocument by catching NoSuchIndexException