### PR TITLE
Fix SearchEvent proper return type hint

### DIFF
--- a/Search/Event/SearchEvent.php
+++ b/Search/Event/SearchEvent.php
@@ -29,7 +29,7 @@ class SearchEvent extends AbstractEvent
     }
 
     /**
-     * @return string
+     * @return SearchQuery
      */
     public function getSearchQuery()
     {


### PR DESCRIPTION
I am using phpstan with strict rules and max level and this caught this slipped wrong type hint.