### PR TITLE
Fix php deprecations for jsonSerialize

### DIFF
--- a/Search/Document.php
+++ b/Search/Document.php
@@ -245,6 +245,7 @@ class Document implements \JsonSerializable
         return isset($this->fields[$name]);
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [


### PR DESCRIPTION
Because of:

Deprecated: Return type of Massive\Bundle\SearchBundle\Search\Document::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /vendor/massive/search-bundle/Search/Document.php on line 248

Failing tests are unrelated see `2.9` branch.