### PR TITLE
Add check for non array in field-evaluator

### DIFF
--- a/Search/Metadata/FieldEvaluator.php
+++ b/Search/Metadata/FieldEvaluator.php
@@ -72,6 +72,10 @@ class FieldEvaluator
 
     public function evaluateCondition($object, string $condition)
     {
+        if (!\is_array($object)) {
+            return false;
+        }
+
         try {
             return $this->expressionLanguage->evaluate($condition, $object);
         } catch (\Exception $e) {

--- a/Tests/Unit/Search/Metadata/FieldEvaluatorTest.php
+++ b/Tests/Unit/Search/Metadata/FieldEvaluatorTest.php
@@ -14,24 +14,30 @@ namespace Massive\Bundle\SearchBundle\Tests\Unit\Search\Metadata;
 use Massive\Bundle\SearchBundle\Search\Metadata\Field\Expression;
 use Massive\Bundle\SearchBundle\Search\Metadata\Field\Field;
 use Massive\Bundle\SearchBundle\Search\Metadata\Field\Property;
+use Massive\Bundle\SearchBundle\Search\Metadata\Field\Value;
 use Massive\Bundle\SearchBundle\Search\Metadata\FieldEvaluator;
 use Massive\Bundle\SearchBundle\Search\Metadata\FieldInterface;
-use Massive\Bundle\SearchBundle\Search\ObjectToDocumentConverter;
 use Massive\Bundle\SearchBundle\Tests\Resources\TestBundle\Product;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 class FieldEvaluatorTest extends TestCase
 {
     use ProphecyTrait;
 
     /**
-     * @var ObjectToDocumentConverter
+     * @var FieldEvaluator
      */
     private $fieldEvaluator;
 
-    public function setUp()
+    /**
+     * @var ExpressionLanguage
+     */
+    private $expressionLanguage;
+
+    protected function setUp()
     {
         parent::setUp();
         $this->expressionLanguage = $this->prophesize('Symfony\Component\ExpressionLanguage\ExpressionLanguage');
@@ -43,26 +49,61 @@ class FieldEvaluatorTest extends TestCase
     public function provideGetValue()
     {
         return [
-            [
+            'Field with string value' => [
                 new Field('title'),
                 [
                     'title' => 'My product',
                 ],
                 'My product',
             ],
-            [
+            'Property with string value' => [
                 new Property('title'),
                 [
                     'title' => 'My product',
                 ],
                 'My product',
             ],
-            [
+            'Expression' => [
                 new Expression('object.title'),
                 [
                     'title' => 'My product',
                 ],
                 'this_was_evaluated',
+            ],
+            'Field with integer value' => [
+                new Field('price'),
+                [
+                    'price' => 1999,
+                ],
+                1999,
+            ],
+            'Property with boolean value' => [
+                new Property('isActive'),
+                [
+                    'isActive' => true,
+                ],
+                true,
+            ],
+            'Field with array value' => [
+                new Field('tags'),
+                [
+                    'tags' => ['tag1', 'tag2'],
+                ],
+                ['tag1', 'tag2'],
+            ],
+            'Property with null value' => [
+                new Property('description'),
+                [
+                    'description' => null,
+                ],
+                null,
+            ],
+            'Field with object value' => [
+                new Field('category'),
+                [
+                    'category' => 'Electronics',
+                ],
+                'Electronics',
             ],
         ];
     }
@@ -78,6 +119,110 @@ class FieldEvaluatorTest extends TestCase
         }
 
         $result = $this->fieldEvaluator->getValue($product, $field);
-        $this->assertEquals($expectedValue, $result);
+        $this->assertSame($expectedValue, $result);
+    }
+
+    public function testGetValueWithValue()
+    {
+        // Create a real Value instance instead of a mock
+        $valueField = new Value('static value');
+
+        $result = $this->fieldEvaluator->getValue(new Product(), $valueField);
+        $this->assertSame('static value', $result);
+    }
+
+    public function testGetValueWithArrayAndField()
+    {
+        $field = new Field('name');
+        $data = ['name' => 'Array value'];
+
+        $result = $this->fieldEvaluator->getValue($data, $field);
+        $this->assertSame('Array value', $result);
+    }
+
+    public function testGetValueWithInvalidFieldType()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unknown field type');
+
+        $invalidField = $this->prophesize(FieldInterface::class)->reveal();
+        $this->fieldEvaluator->getValue(new Product(), $invalidField);
+    }
+
+    public function testGetValueWithInvalidPropertyAccess()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Error encountered when trying to determine value');
+
+        $product = new Product();
+        $field = new Property('nonexistentProperty');
+
+        $this->fieldEvaluator->getValue($product, $field);
+    }
+
+    public function testGetExpressionValueWithError()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Error encountered when trying to determine value');
+
+        $this->expressionLanguage->evaluate(Argument::any(), Argument::any())
+            ->willThrow(new \Exception('Expression error'));
+
+        $product = new Product();
+        $field = new Expression('object.something');
+
+        $this->fieldEvaluator->getValue($product, $field);
+    }
+
+    public function provideEvaluateCondition()
+    {
+        return [
+            'True condition' => [
+                ['age' => 25, 'active' => true],
+                'age > 18 and active == true',
+                true,
+            ],
+            'False condition' => [
+                ['age' => 15, 'active' => true],
+                'age > 18 and active == true',
+                false,
+            ],
+            'Complex condition' => [
+                ['price' => 100, 'discount' => 20, 'stock' => 5],
+                'price > 50 and (discount > 10 or stock > 10)',
+                true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideEvaluateCondition
+     */
+    public function testEvaluateCondition(array $object, string $condition, bool $expected)
+    {
+        $expressionLanguage = new ExpressionLanguage();
+        $fieldEvaluator = new FieldEvaluator($expressionLanguage);
+
+        $result = $fieldEvaluator->evaluateCondition($object, $condition);
+        $this->assertSame($expected, $result);
+    }
+
+    public function testEvaluateConditionWithNonArrayObject()
+    {
+        $product = new Product();
+        $result = $this->fieldEvaluator->evaluateCondition($product, 'whatever');
+
+        $this->assertFalse($result);
+    }
+
+    public function testEvaluateConditionWithError()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Error encountered when evaluating expression');
+
+        $this->expressionLanguage->evaluate(Argument::any(), Argument::any())
+            ->willThrow(new \Exception('Expression error'));
+
+        $this->fieldEvaluator->evaluateCondition(['test' => true], 'invalid_syntax');
     }
 }


### PR DESCRIPTION
The `$this->expressionLanguage->evaluate($condition, $object);` expect only a array.