### PR TITLE
Avoid serialization loop with IndexMetadata during serialization

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -78,7 +78,15 @@ jobs:
                     - php-version: '8.3'
                       elasticsearch-version: '7.17.19'
                       elasticsearch-package-constraint: '~7.17.0'
-                      minimum-stability: 'dev'
+                      minimum-stability: 'stable'
+                      dependency-versions: 'highest'
+                      tools: 'composer:v2'
+                      php-cs-fixer: false
+
+                    - php-version: '8.4'
+                      elasticsearch-version: '7.17.19'
+                      elasticsearch-package-constraint: '~7.17.0'
+                      minimum-stability: 'stable'
                       dependency-versions: 'highest'
                       tools: 'composer:v2'
                       php-cs-fixer: false

--- a/Search/Metadata/ClassMetadata.php
+++ b/Search/Metadata/ClassMetadata.php
@@ -90,6 +90,9 @@ class ClassMetadata extends BaseClassMetadata implements \Serializable
         list($data, $indexMetadata, $this->repositoryMethod) = $data;
         parent::unserializeFromArray($data);
         $this->indexMetadatas = $indexMetadata;
+        foreach ($this->indexMetadatas as $indexMetadata) {
+            $indexMetadata->setClassMetadata($this);
+        }
     }
 
     /**

--- a/Search/Metadata/IndexMetadata.php
+++ b/Search/Metadata/IndexMetadata.php
@@ -201,7 +201,7 @@ class IndexMetadata implements IndexMetadataInterface, \Serializable
             $this->titleField,
             $this->descriptionField,
             $this->imageUrlField,
-            $this->localeField,
+            $this->localeField
         ) = $data;
     }
 }

--- a/Search/Metadata/IndexMetadata.php
+++ b/Search/Metadata/IndexMetadata.php
@@ -11,11 +11,15 @@
 
 namespace Massive\Bundle\SearchBundle\Search\Metadata;
 
+use Metadata\SerializationHelper;
+
 /**
  * Metadata for searchable objects.
  */
-class IndexMetadata implements IndexMetadataInterface
+class IndexMetadata implements IndexMetadataInterface, \Serializable
 {
+    use SerializationHelper;
+
     /**
      * @var string
      */
@@ -169,5 +173,35 @@ class IndexMetadata implements IndexMetadataInterface
     public function setClassMetadata(ClassMetadata $classMetadata)
     {
         $this->classMetadata = $classMetadata;
+    }
+
+    public function serializeToArray(): array
+    {
+        return [
+            $this->name,
+            $this->indexName,
+            $this->fieldMapping,
+            $this->idField,
+            $this->urlField,
+            $this->titleField,
+            $this->descriptionField,
+            $this->imageUrlField,
+            $this->localeField,
+        ];
+    }
+
+    public function unserializeFromArray(array $data): void
+    {
+        list(
+            $this->name,
+            $this->indexName,
+            $this->fieldMapping,
+            $this->idField,
+            $this->urlField,
+            $this->titleField,
+            $this->descriptionField,
+            $this->imageUrlField,
+            $this->localeField,
+        ) = $data;
     }
 }

--- a/Tests/Unit/Search/Metadata/ClassMetadataTest.php
+++ b/Tests/Unit/Search/Metadata/ClassMetadataTest.php
@@ -74,4 +74,15 @@ class ClassMetadataTest extends TestCase
 
         $this->assertEquals($this->classMetadata, \unserialize(\serialize($this->classMetadata)));
     }
+
+    public function testSerializeUnserializeWithIndexMetadata()
+    {
+        $classMetadata = new ClassMetadata('\stdClass');
+        $classMetadata->addIndexMetadata(
+            'foo_context',
+            new IndexMetadata()
+        );
+
+        $this->assertEquals($classMetadata, \unserialize(\serialize($classMetadata)));
+    }
 }


### PR DESCRIPTION
Issues appear during saving a category or similiar in sulu admin the metadata serilaization ending in:

> terminated by signal SIGSEGV (Address boundary erro

Or for others as reported

> [2025-10-29T15:49:24.795061+01:00] request.CRITICAL: Uncaught PHP Exception Error: "Maximum call stack size of 8339456 bytes (zend.max_allowed_stack_size - zend.reserved_stack_size) reached. Infinite recursion?" at SerializationHelper.php line 16 {"exception":"[object] (Error(code: 0): Maximum call stack size of 8339456 bytes (zend.max_allowed_stack_size - zend.reserved_stack_size) reached. Infinite recursion? at /data/sites/web/<user>/subsites/<subsite>/vendor/jms/metadata/src/SerializationHelper.php:16)"} []

---

PS: Issues is related to the newly released versions of PHP 8.3.27 and 8.4.14, see https://github.com/php/php-src/issues/20338, PHP versions before are not effect by the bug, but update still recommended.